### PR TITLE
Cleaned up LimitedQueue and its Snapshot class

### DIFF
--- a/messages/limitedqueue.h
+++ b/messages/limitedqueue.h
@@ -3,8 +3,6 @@
 
 #include "messages/limitedqueuesnapshot.h"
 
-#include <boost/signals2.hpp>
-
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -17,14 +15,13 @@ class LimitedQueue
 {
 public:
     LimitedQueue(int limit = 100, int buffer = 25)
-        : vector(new std::vector<T>(limit + buffer))
-        , vectorPtr(this->vector)
-        , mutex()
+        : mutex()
         , offset(0)
-        , length(0)
         , limit(limit)
         , buffer(buffer)
     {
+        vector = std::make_shared<std::vector<T>>();
+        vector->reserve(this->limit + this->buffer);
     }
 
     void
@@ -32,11 +29,10 @@ public:
     {
         std::lock_guard<std::mutex> lock(this->mutex);
 
-        this->vector = new std::vector<T>(this->limit + this->buffer);
-        this->vectorPtr = std::shared_ptr<std::vector<T>>(this->vector);
+        this->vector = std::make_shared<std::vector<T>>();
+        this->vector->reserve(this->limit + this->buffer);
 
         this->offset = 0;
-        this->length = 0;
     }
 
     // return true if an item was deleted
@@ -46,39 +42,36 @@ public:
     {
         std::lock_guard<std::mutex> lock(this->mutex);
 
-        if (this->length == this->limit) {
+        if (this->vector->size() >= this->limit) {
             // vector is full
             if (this->offset == this->buffer) {
                 deleted = this->vector->at(this->offset);
 
                 // create new vector
-                auto *vector = new std::vector<T>(this->limit + this->buffer);
+                auto newVector = std::make_shared<std::vector<T>>();
+                newVector->reserve(this->limit + this->buffer);
 
-                for (int i = 0; i < this->limit; i++) {
-                    vector->at(i) = this->vector->at(i + this->offset);
+                for (unsigned int i = 0; i < this->limit - 1; i++) {
+                    newVector->push_back(this->vector->at(i + this->offset));
                 }
-
-                vector->at(limit - 1) = item;
+                newVector->push_back(item);
 
                 this->offset = 0;
-
-                this->vector = vector;
-                this->vectorPtr = std::shared_ptr<std::vector<T>>(vector);
+                this->vector = newVector;
 
                 return true;
             } else {
-                // append item and remove first
                 deleted = this->vector->at(this->offset);
 
-                this->vector->at(this->length + this->offset) = item;
+                //append item and increment offset("deleting" first element)
+                this->vector->push_back(item);
                 this->offset++;
 
                 return true;
             }
         } else {
             // append item
-            this->vector->at(this->length) = item;
-            this->length++;
+            this->vector->push_back(item);
 
             return false;
         }
@@ -87,21 +80,23 @@ public:
     messages::LimitedQueueSnapshot<T>
     getSnapshot()
     {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::lock_guard<std::mutex> lock(this->mutex);
 
-        return LimitedQueueSnapshot<T>(vectorPtr, offset, length);
+        if(vector->size() < limit) {
+            return LimitedQueueSnapshot<T>(this->vector, this->offset, this->vector->size());
+        } else {
+            return LimitedQueueSnapshot<T>(this->vector, this->offset, this->limit);
+        }
     }
 
 private:
-    std::vector<T> *vector;
-    std::shared_ptr<std::vector<T>> vectorPtr;
+    std::shared_ptr<std::vector<T>> vector;
 
     std::mutex mutex;
 
-    int offset;
-    int length;
-    int limit;
-    int buffer;
+    unsigned int offset;
+    unsigned int limit;
+    unsigned int buffer;
 };
 
 }  // namespace messages

--- a/messages/limitedqueuesnapshot.h
+++ b/messages/limitedqueuesnapshot.h
@@ -1,7 +1,6 @@
 #ifndef LIMITEDQUEUESNAPSHOT_H
 #define LIMITEDQUEUESNAPSHOT_H
 
-#include <cassert>
 #include <memory>
 #include <vector>
 
@@ -14,8 +13,7 @@ class LimitedQueueSnapshot
 public:
     LimitedQueueSnapshot(std::shared_ptr<std::vector<T>> ptr, int offset,
                          int length)
-        : vectorPtr(ptr)
-        , vector(ptr.get())
+        : vector(ptr)
         , offset(offset)
         , length(length)
     {
@@ -24,20 +22,16 @@ public:
     int
     getLength()
     {
-        return length;
+        return this->length;
     }
 
     T const &operator[](int index) const
     {
-        //        assert(index >= 0);
-        //        assert(index < length);
-
-        return vector->at(index + offset);
+        return this->vector->at(index + this->offset);
     }
 
 private:
-    std::shared_ptr<std::vector<T>> vectorPtr;
-    std::vector<T> *vector;
+    std::shared_ptr<std::vector<T>> vector;
 
     int offset;
     int length;


### PR DESCRIPTION
Deleted unnecessary variables (a std::vector pointer and the length).
Reserving the space for all messages instead of default constructing them when creating the vector.