### PR TITLE
Enable C++14 for Qt Creator on OS X

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -9,6 +9,8 @@ CONFIG  += communi
 COMMUNI += core model util
 CONFIG  += c++14
 
+QMAKE_CXXFLAGS += -stdlib=libc++
+
 include(lib/libcommuni/src/src.pri)
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets


### PR DESCRIPTION
Seems like there's a glitch where the standard libraries aren't included when using the c++14 config flag. This gets fixed by adding the following line to the .pro file:```
QMAKE_CXXFLAGS += -stdlib=libc++ ```