### PR TITLE
fix wrong variable name, openChannelNameDialog on ctrl+t, give focus to new split

### DIFF
--- a/src/widgets/chatwidget.cpp
+++ b/src/widgets/chatwidget.cpp
@@ -224,7 +224,7 @@ boost::property_tree::ptree ChatWidget::save()
 void ChatWidget::doAddSplit()
 {
     NotebookPage *page = static_cast<NotebookPage *>(this->parentWidget());
-    page->addChat();
+    page->addChat(true);
 }
 
 void ChatWidget::doCloseSplit()

--- a/src/widgets/notebookpage.cpp
+++ b/src/widgets/notebookpage.cpp
@@ -103,6 +103,7 @@ void NotebookPage::addToLayout(ChatWidget *widget,
                                std::pair<int, int> position = std::pair<int, int>(-1, -1))
 {
     _chatWidgets.push_back(widget);
+    widget->giveFocus();
 
     // add vbox at the end
     if (position.first < 0 || position.first >= _hbox.count()) {

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -13,11 +13,10 @@ namespace widgets {
 
 ScrollBar::ScrollBar(ChatWidgetView *parent)
     : BaseWidget(parent)
-    , _currentValueAnimation(this, "currentValue")
+    , _currentValueAnimation(this, "_currentValue")
     , _highlights(nullptr)
 {
     resize(16, 100);
-
     _currentValueAnimation.setDuration(250);
     _currentValueAnimation.setEasingCurve(QEasingCurve(QEasingCurve::OutCubic));
 


### PR DESCRIPTION
the _currentValue should fix scrollbar (atleast it does for me), without it cannot scroll with mousewheel plus dragging the scrollbar with mouse is kinda bugged too