### PR TITLE
Adds viewer list + livechecks

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -63,6 +63,12 @@ const QString &Channel::getPopoutPlayerLink() const
     return _popoutPlayerLink;
 }
 
+void Channel::setRoomID(std::string id)
+{
+    this->roomID = id;
+    this->roomIDchanged();
+}
+
 messages::LimitedQueueSnapshot<messages::SharedMessage> Channel::getMessageSnapshot()
 {
     return _messages.getSnapshot();

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -29,6 +29,7 @@ Channel::Channel(WindowManager &_windowManager, EmoteManager &_emoteManager,
     , _subLink("https://www.twitch.tv/" + name + "/subscribe?ref=in_chat_subscriber_link")
     , _channelLink("https://twitch.tv/" + name)
     , _popoutPlayerLink("https://player.twitch.tv/?channel=" + name)
+    , isLive(false)
 //    , _loggingChannel(logging::get(_name))
 {
     qDebug() << "Open channel:" << this->name;
@@ -60,26 +61,6 @@ const QString &Channel::getChannelLink() const
 const QString &Channel::getPopoutPlayerLink() const
 {
     return _popoutPlayerLink;
-}
-
-bool Channel::getIsLive() const
-{
-    return _isLive;
-}
-
-int Channel::getStreamViewerCount() const
-{
-    return _streamViewerCount;
-}
-
-const QString &Channel::getStreamStatus() const
-{
-    return _streamStatus;
-}
-
-const QString &Channel::getStreamGame() const
-{
-    return _streamGame;
 }
 
 messages::LimitedQueueSnapshot<messages::SharedMessage> Channel::getMessageSnapshot()

--- a/src/channel.hpp
+++ b/src/channel.hpp
@@ -53,6 +53,11 @@ public:
 
     std::string roomID;
     const QString name;
+    bool isLive;
+    QString streamViewerCount;
+    QString streamStatus;
+    QString streamGame;
+    QString streamUptime;
 
 private:
     // variables
@@ -67,10 +72,6 @@ private:
     QString _channelLink;
     QString _popoutPlayerLink;
 
-    bool _isLive;
-    int _streamViewerCount;
-    QString _streamStatus;
-    QString _streamGame;
     // std::shared_ptr<logging::Channel> _loggingChannel;
 };
 

--- a/src/channel.hpp
+++ b/src/channel.hpp
@@ -39,10 +39,6 @@ public:
     const QString &getSubLink() const;
     const QString &getChannelLink() const;
     const QString &getPopoutPlayerLink() const;
-    bool getIsLive() const;
-    int getStreamViewerCount() const;
-    const QString &getStreamStatus() const;
-    const QString &getStreamGame() const;
     messages::LimitedQueueSnapshot<messages::SharedMessage> getMessageSnapshot();
 
     // methods
@@ -58,6 +54,9 @@ public:
     QString streamStatus;
     QString streamGame;
     QString streamUptime;
+
+    void setRoomID(std::string id);
+    boost::signals2::signal<void()> roomIDchanged;
 
 private:
     // variables

--- a/src/ircmanager.cpp
+++ b/src/ircmanager.cpp
@@ -283,7 +283,7 @@ void IrcManager::handleRoomStateMessage(Communi::IrcMessage *message)
         std::string roomID = iterator.value().toString().toStdString();
 
         auto channel = QString(message->toData()).split("#").at(1);
-        channelManager.getChannel(channel)->roomID = roomID;
+        channelManager.getChannel(channel)->setRoomID(roomID);
 
         this->resources.loadChannelData(roomID);
     }

--- a/src/ircmanager.cpp
+++ b/src/ircmanager.cpp
@@ -282,6 +282,9 @@ void IrcManager::handleRoomStateMessage(Communi::IrcMessage *message)
     if (iterator != tags.end()) {
         std::string roomID = iterator.value().toString().toStdString();
 
+        auto channel = QString(message->toData()).split("#").at(1);
+        channelManager.getChannel(channel)->roomID = roomID;
+
         this->resources.loadChannelData(roomID);
     }
 }

--- a/src/widgets/chatwidget.cpp
+++ b/src/widgets/chatwidget.cpp
@@ -244,6 +244,9 @@ void ChatWidget::doCloseSplit()
 {
     NotebookPage *page = static_cast<NotebookPage *>(this->parentWidget());
     page->removeFromLayout(this);
+    QTimer* timer = this->header.findChild<QTimer*>();
+    timer->stop();
+    timer->deleteLater();
 }
 
 void ChatWidget::doChangeChannel()

--- a/src/widgets/chatwidget.cpp
+++ b/src/widgets/chatwidget.cpp
@@ -91,6 +91,9 @@ std::shared_ptr<Channel> &ChatWidget::getChannelRef()
 void ChatWidget::setChannel(std::shared_ptr<Channel> _newChannel)
 {
     this->channel = _newChannel;
+    this->channel->roomIDchanged.connect([this](){
+        this->header.checkLive();
+    });
 
     // on new message
     this->messageAppendedConnection =

--- a/src/widgets/chatwidget.cpp
+++ b/src/widgets/chatwidget.cpp
@@ -322,37 +322,27 @@ void ChatWidget::doOpenViewerList()
     auto chattersList = new QListWidget();
     auto resultList = new QListWidget();
 
-    auto modLabel = new QListWidgetItem("Moderators");
-    modLabel->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
-    auto staffLabel = new QListWidgetItem("Staff");
-    staffLabel->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
-    auto adminLabel = new QListWidgetItem("Admins");
-    adminLabel->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
-    auto gmodLabel = new QListWidgetItem("Global Moderators");
-    gmodLabel->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
-    auto viewerLabel = new QListWidgetItem("Viewers");
-    viewerLabel->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
+    static QStringList labels = {"Moderators", "Staff", "Admins", "Global Moderators", "Viewers"};
+    static QStringList jsonLabels = {"moderators", "staff", "admins", "global_mods", "viewers"};
+    QList<QListWidgetItem*> labelList;
+    for(auto &x : labels)
+    {
+        auto label = new QListWidgetItem(x);
+        label->setBackgroundColor(this->colorScheme.ChatHeaderBackground);
+        labelList.append(label);
+    }
     auto loadingLabel = new QLabel("Loading...");
 
     util::twitch::get("https://tmi.twitch.tv/group/user/" + channel->name + "/chatters",[=](QJsonObject obj){
         QJsonObject chattersObj = obj.value("chatters").toObject();
 
         loadingLabel->hide();
-        chattersList->addItem(modLabel);
-        foreach (const QJsonValue & v, chattersObj.value("moderators").toArray())
-            chattersList->addItem(v.toString());
-        chattersList->addItem(staffLabel);
-        foreach (const QJsonValue & v, chattersObj.value("staff").toArray())
-            chattersList->addItem(v.toString());
-        chattersList->addItem(adminLabel);
-        foreach (const QJsonValue & v, chattersObj.value("admins").toArray())
-            chattersList->addItem(v.toString());
-        chattersList->addItem(gmodLabel);
-        foreach (const QJsonValue & v, chattersObj.value("global_mods").toArray())
-            chattersList->addItem(v.toString());
-        chattersList->addItem(viewerLabel);
-        foreach (const QJsonValue & v, chattersObj.value("viewers").toArray())
-            chattersList->addItem(v.toString());
+        for(int i = 0; i < jsonLabels.size(); i++)
+        {
+            chattersList->addItem(labelList.at(i));
+            foreach (const QJsonValue & v, chattersObj.value(jsonLabels.at(i)).toArray())
+                chattersList->addItem(v.toString());
+        }
     });
 
     searchBar->setPlaceholderText("Search User...");
@@ -365,7 +355,8 @@ void ChatWidget::doOpenViewerList()
             resultList->clear();
             for (auto & item : results)
             {
-                resultList->addItem(item->text());
+                if(!labels.contains(item->text()))
+                    resultList->addItem(item->text());
             }
             resultList->show();
         }

--- a/src/widgets/chatwidget.hpp
+++ b/src/widgets/chatwidget.hpp
@@ -115,6 +115,9 @@ public slots:
 
     // Open twitch channel stream through streamlink
     void doOpenStreamlink();
+
+    // Open viewer list of the channel
+    void doOpenViewerList();
 };
 
 }  // namespace widgets

--- a/src/widgets/chatwidgetheader.cpp
+++ b/src/widgets/chatwidgetheader.cpp
@@ -45,6 +45,7 @@ ChatWidgetHeader::ChatWidgetHeader(ChatWidget *_chatWidget)
                              QKeySequence(tr("Ctrl+W")));
     this->leftMenu.addAction("Move split", this, SLOT(menuMoveSplit()));
     this->leftMenu.addAction("Popup", this->chatWidget, &ChatWidget::doPopup);
+    this->leftMenu.addAction("Open viewer list", this->chatWidget, &ChatWidget::doOpenViewerList);
     this->leftMenu.addSeparator();
     this->leftMenu.addAction("Change channel", this->chatWidget, &ChatWidget::doChangeChannel,
                              QKeySequence(tr("Ctrl+R")));

--- a/src/widgets/chatwidgetheader.cpp
+++ b/src/widgets/chatwidgetheader.cpp
@@ -2,6 +2,7 @@
 #include "colorscheme.hpp"
 #include "widgets/chatwidget.hpp"
 #include "widgets/notebookpage.hpp"
+#include "util/urlfetch.hpp"
 
 #include <QByteArray>
 #include <QDrag>
@@ -67,16 +68,36 @@ ChatWidgetHeader::ChatWidgetHeader(ChatWidget *_chatWidget)
     this->rightLabel.setMinimumWidth(this->height());
     this->rightLabel.getLabel().setTextFormat(Qt::RichText);
     this->rightLabel.getLabel().setText("ayy");
+
+    QTimer *timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, checkLive);
+    timer->start(60000);
 }
 
 void ChatWidgetHeader::updateChannelText()
 {
     const std::string channelName = this->chatWidget->channelName;
-
     if (channelName.empty()) {
         this->channelNameLabel.setText("<no channel>");
     } else {
-        this->channelNameLabel.setText(QString::fromStdString(channelName));
+        if(this->chatWidget->getChannelRef()->isLive)
+        {
+            auto channel = this->chatWidget->getChannelRef();
+            this->channelNameLabel.setText(QString::fromStdString(channelName) + " (live)");
+            this->setToolTip("<style>.center    { text-align: center; }</style>" \
+                             "<p class = \"center\">" + \
+                             channel->streamStatus + "<br><br>" + \
+                             channel->streamGame + "<br>" \
+                             "Live for " + channel->streamUptime + \
+                             " with " + channel->streamViewerCount + " viewers" \
+                             "</p>"
+                             );
+        }
+        else
+        {
+            this->channelNameLabel.setText(QString::fromStdString(channelName));
+            this->setToolTip("");
+        }
     }
 }
 
@@ -171,6 +192,31 @@ void ChatWidgetHeader::menuManualReconnect()
 
 void ChatWidgetHeader::menuShowChangelog()
 {
+}
+
+void ChatWidgetHeader::checkLive()
+{
+    auto channel = this->chatWidget->getChannelRef();
+    auto id = QString::fromStdString(channel->roomID);
+    util::twitch::get("https://api.twitch.tv/kraken/streams/" + id,[=](QJsonObject obj){
+       if(obj.value("stream").isNull())
+       {
+           channel->isLive = false;
+           this->updateChannelText();
+       }
+       else
+       {
+           channel->isLive = true;
+           auto stream = obj.value("stream").toObject();
+           channel->streamViewerCount = QString::number(stream.value("viewers").toDouble());
+           channel->streamGame = stream.value("game").toString();
+           channel->streamStatus = stream.value("channel").toObject().value("status").toString();
+           QDateTime since = QDateTime::fromString(stream.value("created_at").toString(),Qt::ISODate);
+           auto diff = since.secsTo(QDateTime::currentDateTime());
+           channel->streamUptime = QString::number(diff/3600) + "h " + QString::number(diff % 3600 / 60) + "m";
+           this->updateChannelText();
+       }
+    });
 }
 
 }  // namespace widgets

--- a/src/widgets/chatwidgetheader.hpp
+++ b/src/widgets/chatwidgetheader.hpp
@@ -27,9 +27,9 @@ class ChatWidgetHeader : public BaseWidget
 
 public:
     explicit ChatWidgetHeader(ChatWidget *_chatWidget);
-
     // Update channel text from chat widget
     void updateChannelText();
+    void checkLive();
 
 protected:
     virtual void paintEvent(QPaintEvent *) override;
@@ -66,6 +66,7 @@ public slots:
     void menuReloadChannelEmotes();
     void menuManualReconnect();
     void menuShowChangelog();
+
 };
 
 }  // namespace widgets


### PR DESCRIPTION
Checks if a channel is live every 60s and changes the name in header to reflect the status. Tooltip on hover over the chatwidgetheader shows the same info that it did in the old Chatterino.
Also adds the correct Twitch-API v5 id to the channel.

Adds a viewer list contextmenu option in the header. Viewer list is dockable and and has a live search field.