### PR TITLE
Made libcommuni show as 'libcommuni' in Qt Creator instead of 'src'

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -9,9 +9,6 @@ CONFIG  += communi
 COMMUNI += core model util
 CONFIG  += c++14
 
-DEFINES += IRC_NAMESPACE=Communi
-include(lib/libcommuni/src/src.pri)
-
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 # Include ourself
@@ -220,3 +217,6 @@ include(dependencies/settings.pri)
 include(dependencies/signals.pri)
 include(dependencies/humanize.pri)
 include(dependencies/fmt.pri)
+DEFINES += IRC_NAMESPACE=Communi
+include(dependencies/libcommuni.pri)
+

--- a/dependencies/libcommuni.pri
+++ b/dependencies/libcommuni.pri
@@ -1,0 +1,3 @@
+include(../lib/libcommuni/src/core/core.pri)
+include(../lib/libcommuni/src/model/model.pri)
+include(../lib/libcommuni/src/util/util.pri)


### PR DESCRIPTION
Just a simple convenience fix.