### PR TITLE
Added Qt::X11BypassWindowManagerHint to the WindowFlags of ToolTipWidget

### DIFF
--- a/src/widgets/tooltipwidget.cpp
+++ b/src/widgets/tooltipwidget.cpp
@@ -25,7 +25,7 @@ TooltipWidget::TooltipWidget(BaseWidget *parent)
                                                      this->getDpiMultiplier()));
 
     this->setAttribute(Qt::WA_ShowWithoutActivating);
-    this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
 
     displayText->setAlignment(Qt::AlignHCenter);
     displayText->setText("lmao xD");


### PR DESCRIPTION
It fixes the issue of the new "window" in the taskbar.
At least in Linux