### PR TITLE
Remove the Twitch Channel when closing the split

### DIFF
--- a/src/widgets/split.cpp
+++ b/src/widgets/split.cpp
@@ -304,8 +304,8 @@ void Split::doAddSplit()
 void Split::doCloseSplit()
 {
     SplitContainer *page = static_cast<SplitContainer *>(this->parentWidget());
-    singletons::ChannelManager::getInstance().removeTwitchChannel(this->channel->name);
     page->removeFromLayout(this);
+    deleteLater();
 }
 
 void Split::doChangeChannel()

--- a/src/widgets/split.cpp
+++ b/src/widgets/split.cpp
@@ -304,6 +304,7 @@ void Split::doAddSplit()
 void Split::doCloseSplit()
 {
     SplitContainer *page = static_cast<SplitContainer *>(this->parentWidget());
+    singletons::ChannelManager::getInstance().removeTwitchChannel(this->channel->name);
     page->removeFromLayout(this);
 }
 


### PR DESCRIPTION
fixes #244 
and another bug where you still got notified of new messages in a closed split in a tab