### PR TITLE
 correct -j flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ download the [boost library](https://sourceforge.net/projects/boost/files/boost/
 
 #### Using MSYS2
 Building using MSYS2 can be quite easier process. Check out MSYS2 at [msys2.org](http://www.msys2.org/).
-Be sure to add "-j <number of cores\*2>" as a make argument so it will use all your cpu cores to build. [example setup](https://i.imgur.com/qlESlS1.png)
+Be sure to add "-j <number of threads>" as a make argument so it will use all your cpu cores to build. [example setup](https://i.imgur.com/qlESlS1.png)
 1. open appropriate MSYS2 terminal and do `pacman -S mingw-w64-<arch>-boost mingw-w64-<arch>-qt5 mingw-w64-<arch>-rapidjson` where `<arch>` is x86_64 or i686
 2. go into the project directory
 3. create build folder `mkdir build && cd build`


### PR DESCRIPTION
source (minigw is basically mini GCC so it applies)
https://wiki.gentoo.org/wiki/MAKEOPTS

For example, with the old tip a 4600k with 4 cores and 4 threads would spawn 8 jobs which is a waste of ram. (and slows it down a little) https://blogs.gentoo.org/ago/2013/01/14/makeopts-jcore-1-is-not-the-best-optimization/