### PR TITLE
Fixed live status not updating when channel is online.

### DIFF
--- a/src/providers/twitch/twitchchannel.cpp
+++ b/src/providers/twitch/twitchchannel.cpp
@@ -184,15 +184,15 @@ void TwitchChannel::setLive(bool newLiveStatus)
 {
     {
         std::lock_guard<std::mutex> lock(this->streamStatusMutex);
-        if (this->streamStatus.live == newLiveStatus) {
-            // Nothing changed
-            return;
+        if (this->streamStatus.live != newLiveStatus) {
+            this->streamStatus.live = newLiveStatus;
         }
 
-        this->streamStatus.live = newLiveStatus;
     }
 
-    this->onlineStatusChanged.invoke();
+    if(newLiveStatus) {
+        this->updateLiveInfo.invoke();
+    }
 }
 
 void TwitchChannel::refreshLiveStatus()

--- a/src/providers/twitch/twitchchannel.cpp
+++ b/src/providers/twitch/twitchchannel.cpp
@@ -187,10 +187,9 @@ void TwitchChannel::setLive(bool newLiveStatus)
         if (this->streamStatus.live != newLiveStatus) {
             this->streamStatus.live = newLiveStatus;
         }
-
     }
 
-    if(newLiveStatus) {
+    if (newLiveStatus) {
         this->updateLiveInfo.invoke();
     }
 }

--- a/src/providers/twitch/twitchchannel.hpp
+++ b/src/providers/twitch/twitchchannel.hpp
@@ -54,7 +54,7 @@ public:
 
     void setRoomID(const QString &_roomID);
     pajlada::Signals::NoArgSignal roomIDchanged;
-    pajlada::Signals::NoArgSignal onlineStatusChanged;
+    pajlada::Signals::NoArgSignal updateLiveInfo;
 
     pajlada::Signals::NoArgBoltSignal fetchMessages;
     pajlada::Signals::NoArgSignal userStateChanged;

--- a/src/widgets/helper/splitheader.cpp
+++ b/src/widgets/helper/splitheader.cpp
@@ -136,7 +136,7 @@ void SplitHeader::initializeChannelSignals()
     TwitchChannel *twitchChannel = dynamic_cast<TwitchChannel *>(channel.get());
 
     if (twitchChannel) {
-        twitchChannel->onlineStatusChanged.connect([this]() {
+        twitchChannel->updateLiveInfo.connect([this]() {
             this->updateChannelText();  //
         });
     }


### PR DESCRIPTION
It wasn't updating the info text properly because it never changed the state again after since it would always return before.