### PR TITLE
Changed bit badge overlay text to be consistent with Twitch

### DIFF
--- a/src/providers/twitch/twitchmessagebuilder.cpp
+++ b/src/providers/twitch/twitchmessagebuilder.cpp
@@ -577,7 +577,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
 
             QString cheerAmountQS = badge.mid(5);
             std::string versionKey = cheerAmountQS.toStdString();
-            QString tooltip = QString("cheer ") + cheerAmountQS;
+            QString tooltip = QString("Twitch cheer ") + cheerAmountQS;
 
             // Try to fetch channel-specific bit badge
             try {

--- a/src/providers/twitch/twitchmessagebuilder.cpp
+++ b/src/providers/twitch/twitchmessagebuilder.cpp
@@ -577,7 +577,7 @@ void TwitchMessageBuilder::appendTwitchBadges()
 
             QString cheerAmountQS = badge.mid(5);
             std::string versionKey = cheerAmountQS.toStdString();
-            QString tooltip = QString("Twitch Bits (") + cheerAmountQS + ")";
+            QString tooltip = QString("cheer ") + cheerAmountQS;
 
             // Try to fetch channel-specific bit badge
             try {


### PR DESCRIPTION
Currently it uses "Twitch Bits(x)". Changed to "cheer x" to be consistent with Twitch text overlay.