### PR TITLE
Update macOS instructions

### DIFF
--- a/BUILDING_ON_MAC.md
+++ b/BUILDING_ON_MAC.md
@@ -1,10 +1,11 @@
-# Building on Mac OSX
-1. install Xcode and Xcode Command Line Utilites
-2. start Xcode, settings -> Locations, activate your Command Line Tools
-3. install Qt Creator
-4. install brew https://brew.sh/
-5. `brew install boost openssl rapidjson`
-6. build the project using Qt Creator
+# Building on macOS
+1. Install Xcode and Xcode Command Line Utilites
+2. Start Xcode, settings -> Locations, activate your Command Line Tools
+3. Install brew https://brew.sh/
+4. `brew install boost openssl rapidjson qt`
+5. Go into project directory
+6. Create build folder `mkdir build && cd build`
+7. `qmake .. && make`
 
 If the Project does not build at this point, you might need to add additional Paths/Libs, because brew does not install openssl and boost in the common path. You can get their path using
 

--- a/BUILDING_ON_MAC.md
+++ b/BUILDING_ON_MAC.md
@@ -1,4 +1,5 @@
 # Building on macOS
+#### Note - If you want to develop Chatterino 2 you will also need to install Qt Creator
 1. Install Xcode and Xcode Command Line Utilites
 2. Start Xcode, settings -> Locations, activate your Command Line Tools
 3. Install brew https://brew.sh/


### PR DESCRIPTION
You can easily install qt with brew, so last 3 entries are taken from linux instructions.
Tested on macOS High Sierra (but should work on all macOS versions supported by brew/qt)