### PR TITLE
Make the 'add account' popup box go to foreground

### DIFF
--- a/src/widgets/logindialog.cpp
+++ b/src/widgets/logindialog.cpp
@@ -1,7 +1,7 @@
 #include "widgets/logindialog.hpp"
 #include "common.hpp"
 #include "util/urlfetch.hpp"
-#if FMT_USE_WINDOWS_H
+#if USEWINSDK
 #include <Windows.h>
 #endif
 
@@ -190,7 +190,7 @@ void AdvancedLoginWidget::refreshButtons()
 
 LoginWidget::LoginWidget()
 {
-    #if FMT_USE_WINDOWS_H
+    #if USEWINSDK
     ::SetWindowPos((HWND)this->winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
     #endif
 

--- a/src/widgets/logindialog.cpp
+++ b/src/widgets/logindialog.cpp
@@ -1,7 +1,7 @@
 #include "widgets/logindialog.hpp"
 #include "common.hpp"
 #include "util/urlfetch.hpp"
-#if USEWINSDK
+#ifdef USEWINSDK
 #include <Windows.h>
 #endif
 
@@ -190,7 +190,7 @@ void AdvancedLoginWidget::refreshButtons()
 
 LoginWidget::LoginWidget()
 {
-    #if USEWINSDK
+    #ifdef USEWINSDK
     ::SetWindowPos((HWND)this->winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
     #endif
 

--- a/src/widgets/logindialog.cpp
+++ b/src/widgets/logindialog.cpp
@@ -1,6 +1,9 @@
 #include "widgets/logindialog.hpp"
 #include "common.hpp"
 #include "util/urlfetch.hpp"
+#if FMT_USE_WINDOWS_H
+#include <Windows.h>
+#endif
 
 #include <QClipboard>
 #include <QDebug>
@@ -187,6 +190,10 @@ void AdvancedLoginWidget::refreshButtons()
 
 LoginWidget::LoginWidget()
 {
+    #if FMT_USE_WINDOWS_H
+    ::SetWindowPos((HWND)this->winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+    #endif
+
     this->setLayout(&this->ui.mainLayout);
 
     this->ui.mainLayout.addWidget(&this->ui.tabWidget);

--- a/src/widgets/settingspages/accountspage.cpp
+++ b/src/widgets/settingspages/accountspage.cpp
@@ -9,7 +9,6 @@
 #include "widgets/logindialog.hpp"
 
 #include <algorithm>
-
 #include <QDialogButtonBox>
 #include <QHeaderView>
 #include <QTableView>
@@ -37,6 +36,7 @@ AccountsPage::AccountsPage()
         static auto loginWidget = new LoginWidget();
 
         loginWidget->show();
+        loginWidget->raise();
     });
 
     view->getTableView()->setStyleSheet("background: #333");


### PR DESCRIPTION
Previously it just stayed behind. i only tested this in windows since I don't have any OSX/Linux vms but raise() should just work on them.