### PR TITLE
Add the option to manually update channel text.

### DIFF
--- a/src/widgets/helper/splitheader.cpp
+++ b/src/widgets/helper/splitheader.cpp
@@ -136,9 +136,12 @@ void SplitHeader::addDropdownItems(RippleEffectButton *)
     this->dropdownMenu.addAction("Open in Streamlink", this->split, &Split::doOpenStreamlink);
     this->dropdownMenu.addSeparator();
     this->dropdownMenu.addAction("Reload channel emotes", this, SLOT(menuReloadChannelEmotes()));
+    this->dropdownMenu.addAction("Reload channel stats", this, [this]{
+        updateChannelText();
+    });
     this->dropdownMenu.addAction("Manual reconnect", this, SLOT(menuManualReconnect()));
-    this->dropdownMenu.addSeparator();
-    this->dropdownMenu.addAction("Show changelog", this, SLOT(menuShowChangelog()));
+    //this->dropdownMenu.addSeparator();
+    //this->dropdownMenu.addAction("Show changelog", this, SLOT(menuShowChangelog()));
     // clang-format on
 }
 


### PR DESCRIPTION
This adds the option to manually update the channel text.

So that people can get fresh stats when hovering over a header split, without having to wait for it to update / restarting chatterino.

![image](https://user-images.githubusercontent.com/2313104/41208730-496e8252-6cf4-11e8-8e35-679bd9ac1c7e.png)
