### PR TITLE
Adjust tooltip size

### DIFF
--- a/src/widgets/helper/channelview.cpp
+++ b/src/widgets/helper/channelview.cpp
@@ -805,6 +805,7 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
     } else {
         tooltipWidget->moveTo(this, event->globalPos());
         tooltipWidget->setText(tooltip);
+        tooltipWidget->adjustSize();
         tooltipWidget->show();
         tooltipWidget->raise();
     }


### PR DESCRIPTION
this should fix the broken tooltip sizes when you hover over Word s