### PR TITLE
Fix Account Switcher Popup Widget On Linux

### DIFF
--- a/src/widgets/accountswitchpopupwidget.cpp
+++ b/src/widgets/accountswitchpopupwidget.cpp
@@ -14,8 +14,7 @@ namespace widgets {
 AccountSwitchPopupWidget::AccountSwitchPopupWidget(QWidget *parent)
     : QWidget(parent)
 {
-    this->setWindowFlag(Qt::FramelessWindowHint);
-    this->setWindowFlag(Qt::WindowStaysOnTopHint);
+    this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
 
     this->setContentsMargins(0, 0, 0, 0);
 


### PR DESCRIPTION
In reference to issue #515 

This fixes it for me on Linux.

Not sure if this breaks anything on Windows. Needs some testing.