### PR TITLE
Do not fetch recent messages and viewer list for chatrooms

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -123,7 +123,10 @@ void TwitchChannel::setRoomID(const QString &_roomID)
 {
     this->roomID = _roomID;
     this->roomIDchanged.invoke();
-    this->fetchMessages.invoke();
+
+    if (!this->name.startsWith("chatrooms:")) {
+        this->fetchMessages.invoke();
+    }
 }
 
 void TwitchChannel::reloadChannelEmotes()

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -449,18 +449,22 @@ void Split::doOpenViewerList()
     }
     auto loadingLabel = new QLabel("Loading...");
 
-    twitchApiGet("https://tmi.twitch.tv/group/user/" + this->getChannel()->name + "/chatters", this,
-                 [=](QJsonObject obj) {
-                     QJsonObject chattersObj = obj.value("chatters").toObject();
+    if (!this->getChannel()->name.startsWith("chatrooms:")) {
+        twitchApiGet("https://tmi.twitch.tv/group/user/" + this->getChannel()->name + "/chatters", this,
+                     [=](QJsonObject obj) {
+                         QJsonObject chattersObj = obj.value("chatters").toObject();
 
-                     loadingLabel->hide();
-                     for (int i = 0; i < jsonLabels.size(); i++) {
-                         chattersList->addItem(labelList.at(i));
-                         foreach (const QJsonValue &v,
-                                  chattersObj.value(jsonLabels.at(i)).toArray())
-                             chattersList->addItem(v.toString());
-                     }
-                 });
+                         loadingLabel->hide();
+                         for (int i = 0; i < jsonLabels.size(); i++) {
+                             chattersList->addItem(labelList.at(i));
+                             foreach (const QJsonValue &v,
+                                      chattersObj.value(jsonLabels.at(i)).toArray())
+                                 chattersList->addItem(v.toString());
+                         }
+                     });
+    } else {
+        loadingLabel->hide();
+    }
 
     searchBar->setPlaceholderText("Search User...");
     QObject::connect(searchBar, &QLineEdit::textEdited, this, [=]() {


### PR DESCRIPTION
It is possible to connect to a [chatroom](https://dev.twitch.tv/docs/irc/chat-rooms/) using `chatrooms:<channel ID>:<room UUID>` as channel name.

But `https://tmi.twitch.tv/group/user/<channel name>/chatters` endpoint doesn't return anything,
and `https://tmi.twitch.tv/api/rooms/<room ID>/recent_messages` endpoint returns messages from the general chat of a channel, because `room-id` is the same for all chatrooms.

