### PR TITLE
Fix issue on Windows not matching links correctly.

### DIFF
--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -17,7 +17,7 @@ LinkParser::LinkParser(const QString &unparsedString)
         t1.setCodec("UTF-8");
 
         // Read the TLDs in and replace the newlines with pipes
-        QString tldData = t1.readAll().replace("\n", "|");
+        QString tldData = t1.readAll().replace(QRegExp("[\\n]"), "|").remove(QRegExp("[\\s]"));
 
         const QString urlRegExp =
             "^"


### PR DESCRIPTION
Fixed an issue where links were not being highlighted correctly because of improper parsing and formatting of the tlds.txt file.

Before code-fix
![image](https://user-images.githubusercontent.com/2313104/42077229-29db7020-7b46-11e8-8094-440c5854f8a1.png)

After code-fix
![image](https://user-images.githubusercontent.com/2313104/42077311-7515482c-7b46-11e8-9c6b-2f2ddf3800b6.png)

I assumed it was because it's only replacing the new line \n and not the return carriage \r

