### PR TITLE
The file-url for logging is now displayed as a smaller link

### DIFF
--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -46,9 +46,9 @@ ModerationPage::ModerationPage()
     {
         // Logs (copied from LoggingMananger)
 
-        auto created = logs.emplace<QLabel>();
+        auto logsPathLabel = logs.emplace<QLabel>();
 
-        app->settings->logPath.connect([app, created](const QString &logPath, auto) mutable {
+        app->settings->logPath.connect([app, logsPathLabel](const QString &logPath, auto) mutable {
 
             QString pathOriginal;
 
@@ -71,14 +71,15 @@ ModerationPage::ModerationPage()
             pathShortened = "Logs saved at <a href=\"file:///" + pathOriginal +
                             "\"><span style=\"color: white;\">" + pathShortened + "</span></a>";
 
-            created->setText(pathShortened);
+            logsPathLabel->setText(pathShortened);
+            logsPathLabel->setToolTip(pathOriginal);
         });
 
-        created->setTextFormat(Qt::RichText);
-        created->setTextInteractionFlags(Qt::TextBrowserInteraction |
-                                         Qt::LinksAccessibleByKeyboard |
-                                         Qt::LinksAccessibleByKeyboard);
-        created->setOpenExternalLinks(true);
+        logsPathLabel->setTextFormat(Qt::RichText);
+        logsPathLabel->setTextInteractionFlags(Qt::TextBrowserInteraction |
+                                               Qt::LinksAccessibleByKeyboard |
+                                               Qt::LinksAccessibleByKeyboard);
+        logsPathLabel->setOpenExternalLinks(true);
         logs.append(this->createCheckBox("Enable logging", app->settings->enableLogging));
 
         logs->addStretch(1);

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -49,12 +49,29 @@ ModerationPage::ModerationPage()
         auto created = logs.emplace<QLabel>();
 
         app->settings->logPath.connect([app, created](const QString &logPath, auto) mutable {
+
+            QString pathOriginal;
+
             if (logPath == "") {
-                created->setText("Logs are saved to " +
-                                 CreateLink(app->paths->messageLogDirectory, true));
+                pathOriginal = app->paths->messageLogDirectory;
             } else {
-                created->setText("Logs are saved to " + CreateLink(logPath, true));
+                pathOriginal = logPath;
             }
+
+            QString pathShortened;
+
+            if (pathOriginal.size() > 50) {
+                pathShortened = pathOriginal;
+                pathShortened.resize(50);
+                pathShortened += "...";
+            } else {
+                pathShortened = pathOriginal;
+            }
+
+            pathShortened = "Logs saved at <a href=\"file:///" + pathOriginal +
+                            "\"><span style=\"color: white;\">" + pathShortened + "</span></a>";
+
+            created->setText(pathShortened);
         });
 
         created->setTextFormat(Qt::RichText);


### PR DESCRIPTION
Not implemented: full link on hover
This fixes some issues when the file-url is too long and messes up the width of the settings window.