### PR TITLE
Lock UI Scale Hotkeys

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -36,6 +36,7 @@ public:
     BoolSetting alternateMessageBackground = {"/appearance/messages/alternateMessageBackground",
                                               false};
     IntSetting uiScale = {"/appearance/uiScale", 0};
+    BoolSetting lockUiScale = {"/appearance/lockUiScale", false};
     BoolSetting windowTopMost = {"/appearance/windowAlwaysOnTop", false};
     BoolSetting showTabCloseButton = {"/appearance/showTabCloseButton", true};
     BoolSetting hidePreferencesButton = {"/appearance/hidePreferencesButton", false};

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -36,7 +36,7 @@ public:
     BoolSetting alternateMessageBackground = {"/appearance/messages/alternateMessageBackground",
                                               false};
     IntSetting uiScale = {"/appearance/uiScale", 0};
-    BoolSetting lockUiScale = {"/appearance/lockUiScale", false};
+    BoolSetting lockUiScaleHotkeys = {"/appearance/lockUiScaleHotkeys", false};
     BoolSetting windowTopMost = {"/appearance/windowAlwaysOnTop", false};
     BoolSetting showTabCloseButton = {"/appearance/showTabCloseButton", true};
     BoolSetting hidePreferencesButton = {"/appearance/hidePreferencesButton", false};

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -497,7 +497,7 @@ int WindowManager::clampUiScale(int scale)
 
 float WindowManager::getUiScaleValue()
 {
-    return getUiScaleValue(getApp()->settings->uiScale.getValue());
+    return getUiScaleValue(getSettings()->uiScale.getValue());
 }
 
 float WindowManager::getUiScaleValue(int scale)

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -60,7 +60,7 @@ BaseWindow::BaseWindow(QWidget *parent, Flags _flags)
     this->updateScale();
 
     createWindowShortcut(this, "CTRL+0", [] {
-        if (!getSettings()->lockUiScale.getValue()) {
+        if (!getSettings()->lockUiScaleHotkeys.getValue()) {
             getSettings()->uiScale.setValue(0);
         }
     });
@@ -259,12 +259,12 @@ void BaseWindow::wheelEvent(QWheelEvent *event)
 
     if (event->modifiers() & Qt::ControlModifier) {
         if (event->delta() > 0) {
-            if (!getSettings()->lockUiScale.getValue()) {
+            if (!getSettings()->lockUiScaleHotkeys.getValue()) {
                 getSettings()->uiScale.setValue(
                     WindowManager::clampUiScale(getSettings()->uiScale.getValue() + 1));
             }
         } else {
-            if (!getSettings()->lockUiScale.getValue()) {
+            if (!getSettings()->lockUiScaleHotkeys.getValue()) {
                 getSettings()->uiScale.setValue(
                     WindowManager::clampUiScale(getSettings()->uiScale.getValue() - 1));
             }

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -54,12 +54,16 @@ BaseWindow::BaseWindow(QWidget *parent, Flags _flags)
     this->init();
 
     this->connections_.managedConnect(
-        getApp()->settings->uiScale.getValueChangedSignal(),
+        getSettings()->uiScale.getValueChangedSignal(),
         [this](auto, auto) { postToThread([this] { this->updateScale(); }); });
 
     this->updateScale();
 
-    createWindowShortcut(this, "CTRL+0", [] { getApp()->settings->uiScale.setValue(0); });
+    createWindowShortcut(this, "CTRL+0", [] {
+        if (!getSettings()->lockUiScale.getValue()) {
+            getSettings()->uiScale.setValue(0);
+        }
+    });
 
     //    QTimer::this->scaleChangedEvent(this->getScale());
 }
@@ -255,11 +259,15 @@ void BaseWindow::wheelEvent(QWheelEvent *event)
 
     if (event->modifiers() & Qt::ControlModifier) {
         if (event->delta() > 0) {
-            getApp()->settings->uiScale.setValue(
-                WindowManager::clampUiScale(getApp()->settings->uiScale.getValue() + 1));
+            if (!getSettings()->lockUiScale.getValue()) {
+                getSettings()->uiScale.setValue(
+                    WindowManager::clampUiScale(getSettings()->uiScale.getValue() + 1));
+            }
         } else {
-            getApp()->settings->uiScale.setValue(
-                WindowManager::clampUiScale(getApp()->settings->uiScale.getValue() - 1));
+            if (!getSettings()->lockUiScale.getValue()) {
+                getSettings()->uiScale.setValue(
+                    WindowManager::clampUiScale(getSettings()->uiScale.getValue() - 1));
+            }
         }
     }
 }

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -263,8 +263,10 @@ void Window::addShortcuts()
         auto s = new QShortcut(QKeySequence::ZoomIn, this);
         s->setContext(Qt::WindowShortcut);
         QObject::connect(s, &QShortcut::activated, this, [] {
-            getApp()->settings->uiScale.setValue(
-                WindowManager::clampUiScale(getApp()->settings->uiScale.getValue() + 1));
+            if (!getSettings()->lockUiScale.getValue()) {
+                getSettings()->uiScale.setValue(
+                    WindowManager::clampUiScale(getSettings()->uiScale.getValue() + 1));
+            }
         });
     }
 
@@ -273,8 +275,10 @@ void Window::addShortcuts()
         auto s = new QShortcut(QKeySequence::ZoomOut, this);
         s->setContext(Qt::WindowShortcut);
         QObject::connect(s, &QShortcut::activated, this, [] {
-            getApp()->settings->uiScale.setValue(
-                WindowManager::clampUiScale(getApp()->settings->uiScale.getValue() - 1));
+            if (!getSettings()->lockUiScale.getValue()) {
+                getSettings()->uiScale.setValue(
+                    WindowManager::clampUiScale(getSettings()->uiScale.getValue() - 1));
+            }
         });
     }
 

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -263,7 +263,7 @@ void Window::addShortcuts()
         auto s = new QShortcut(QKeySequence::ZoomIn, this);
         s->setContext(Qt::WindowShortcut);
         QObject::connect(s, &QShortcut::activated, this, [] {
-            if (!getSettings()->lockUiScale.getValue()) {
+            if (!getSettings()->lockUiScaleHotkeys.getValue()) {
                 getSettings()->uiScale.setValue(
                     WindowManager::clampUiScale(getSettings()->uiScale.getValue() + 1));
             }
@@ -275,7 +275,7 @@ void Window::addShortcuts()
         auto s = new QShortcut(QKeySequence::ZoomOut, this);
         s->setContext(Qt::WindowShortcut);
         QObject::connect(s, &QShortcut::activated, this, [] {
-            if (!getSettings()->lockUiScale.getValue()) {
+            if (!getSettings()->lockUiScaleHotkeys.getValue()) {
                 getSettings()->uiScale.setValue(
                     WindowManager::clampUiScale(getSettings()->uiScale.getValue() - 1));
             }

--- a/src/widgets/settingspages/LookPage.cpp
+++ b/src/widgets/settingspages/LookPage.cpp
@@ -86,7 +86,8 @@ void LookPage::addInterfaceTab(LayoutCreator<QVBoxLayout> layout)
         box.append(this->createUiScaleSlider());
     }
 
-    layout.append(this->createCheckBox("Lock window scale hotkeys", getSettings()->lockUiScale));
+    layout.append(
+        this->createCheckBox("Lock window scale hotkeys", getSettings()->lockUiScaleHotkeys));
 
     layout.append(this->createCheckBox(WINDOW_TOPMOST, getSettings()->windowTopMost));
 

--- a/src/widgets/settingspages/LookPage.cpp
+++ b/src/widgets/settingspages/LookPage.cpp
@@ -86,6 +86,8 @@ void LookPage::addInterfaceTab(LayoutCreator<QVBoxLayout> layout)
         box.append(this->createUiScaleSlider());
     }
 
+    layout.append(this->createCheckBox("Lock window scale hotkeys", getSettings()->lockUiScale));
+
     layout.append(this->createCheckBox(WINDOW_TOPMOST, getSettings()->windowTopMost));
 
     // --


### PR DESCRIPTION
Adds a checkbox to make "Ctrl+Plus", "Ctrl+Minus", "Ctrl+MWheelUp", "Ctrl+MWheelDown", "Ctrl+0" do nothing