### PR TITLE
Minimum window size is limited by the user name

### DIFF
--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -177,6 +177,7 @@ void Window::addCustomTitlebarButtons()
         getApp()->windows->showAccountSelectPopup(
             this->userLabel_->mapToGlobal(this->userLabel_->rect().bottomLeft()));  //
     });
+    this->userLabel_->setMinimumWidth(20 * getScale());
 }
 
 void Window::addDebugStuff()


### PR DESCRIPTION
Fixes the issue when trying to make the chatterino window smaller with long usernames
#528 