### PR TITLE
Fix new emotes not loading properly because of cache

### DIFF
--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -24,7 +24,6 @@ void BTTVEmotes::loadGlobalEmotes()
     NetworkRequest request(url);
     request.setCaller(QThread::currentThread());
     request.setTimeout(30000);
-    request.setUseQuickLoadCache(true);
     request.onSuccess([this](auto result) {
         auto root = result.parseJson();
         auto emotes = root.value("emotes").toArray();
@@ -68,7 +67,6 @@ void BTTVEmotes::loadChannelEmotes(const QString &channelName, std::weak_ptr<Emo
     NetworkRequest request(url);
     request.setCaller(QThread::currentThread());
     request.setTimeout(3000);
-    request.setUseQuickLoadCache(true);
     request.onSuccess([this, channelName, _map](auto result) {
         auto rootNode = result.parseJson();
         auto map = _map.lock();

--- a/src/providers/ffz/FfzEmotes.cpp
+++ b/src/providers/ffz/FfzEmotes.cpp
@@ -49,7 +49,6 @@ void FFZEmotes::loadGlobalEmotes()
     NetworkRequest request(url);
     request.setCaller(QThread::currentThread());
     request.setTimeout(30000);
-    request.setUseQuickLoadCache(true);
     request.onSuccess([this](auto result) {
         auto root = result.parseJson();
         auto sets = root.value("sets").toObject();
@@ -92,7 +91,6 @@ void FFZEmotes::loadChannelEmotes(const QString &channelName, std::weak_ptr<Emot
     NetworkRequest request(url);
     request.setCaller(QThread::currentThread());
     request.setTimeout(3000);
-    request.setUseQuickLoadCache(true);
     request.onSuccess([this, channelName, _map](auto result) {
         auto rootNode = result.parseJson();
         auto map = _map.lock();


### PR DESCRIPTION
As recommended by pajlada [here](https://github.com/fourtf/chatterino2/issues/595#issuecomment-403852365).