### PR TITLE
Add support for spotify hyperlinking

### DIFF
--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -20,9 +20,16 @@ LinkParser::LinkParser(const QString &unparsedString)
         // Read the TLDs in and replace the newlines with pipes
         QString tldData = t1.readAll().replace(newLineRegex, "|");
 
-        const QString urlRegExp =
+        const QString hyperlinkRegExp =
             "^"
-            // protocol identifier
+            // Identifier for spotify
+            "(?x-mi:(spotify:(?:"
+            "(?:artist|album|track|user:[^:]+:playlist):"
+            "[a-zA-Z0-9]+|user:[^:]+|search:"
+            "(?:[-\\w$\\.+!*'(),]+|%[a-fA-F0-9]{2})+)))"
+            // If nothing matches then just go on
+            "|"
+            // Identifier for http and ftp
             "(?:(?:https?|ftps?)://)?"
             // user:pass authentication
             "(?:\\S+(?::\\S*)?@)?"
@@ -53,7 +60,7 @@ LinkParser::LinkParser(const QString &unparsedString)
             "(?:[/?#]\\S*)?"
             "$";
 
-        return QRegularExpression(urlRegExp, QRegularExpression::CaseInsensitiveOption);
+        return QRegularExpression(hyperlinkRegExp, QRegularExpression::CaseInsensitiveOption);
     }();
 
     this->match_ = linkRegex.match(unparsedString);

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -49,6 +49,7 @@ QString MessageBuilder::matchLink(const QString &string)
 
     static QRegularExpression httpRegex("\\bhttps?://", QRegularExpression::CaseInsensitiveOption);
     static QRegularExpression ftpRegex("\\bftps?://", QRegularExpression::CaseInsensitiveOption);
+    static QRegularExpression spotifyRegex("\\bspotify:", QRegularExpression::CaseInsensitiveOption);
 
     if (!linkParser.hasMatch()) {
         return QString();
@@ -56,10 +57,8 @@ QString MessageBuilder::matchLink(const QString &string)
 
     QString captured = linkParser.getCaptured();
 
-    if (!captured.contains(httpRegex)) {
-        if (!captured.contains(ftpRegex)) {
-            captured.insert(0, "http://");
-        }
+    if (!captured.contains(httpRegex) && !captured.contains(ftpRegex) && !captured.contains(spotifyRegex)) {
+        captured.insert(0, "http://");
     }
 
     return captured;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1067,7 +1067,7 @@ void ChannelView::addContextMenuItems(const MessageLayoutElement *hoveredElement
     if (hoveredElement->getLink().type == Link::Url) {
         QString url = hoveredElement->getLink().value;
 
-        menu->addAction("Open link in browser", [url] { QDesktopServices::openUrl(QUrl(url)); });
+        menu->addAction("Open link", [url] { QDesktopServices::openUrl(QUrl(url)); });
         menu->addAction("Copy link", [url] { QApplication::clipboard()->setText(url); });
 
         menu->addSeparator();


### PR DESCRIPTION
Supports hyperlinking spotify: links such as

> spotify:search:omg%2bwtf%2b%ef%a3%bf%c3%9f%e2%88%82%2bbbq
> 
> spotify:track:3oN2Kq1h07LSSBSLYQp0Ns
> 
> spotify:album:6I58XCEkOnfUVsfpDehzlQ
> 
> spotify:artist:6MF9fzBmfXghAz953czmBC
> 
> spotify:user:radiofy.se:playlist:50aHxwoLzq2fvo5g97c2T2
> 
> spotify:user:radiofy.se