### PR TITLE
Fix match linking

### DIFF
--- a/src/common/LinkParser.cpp
+++ b/src/common/LinkParser.cpp
@@ -29,6 +29,7 @@ LinkParser::LinkParser(const QString &unparsedString)
             "(?:[-\\w$\\.+!*'(),]+|%[a-fA-F0-9]{2})+)))"
             // If nothing matches then just go on
             "|"
+            "^"
             // Identifier for http and ftp
             "(?:(?:https?|ftps?)://)?"
             // user:pass authentication


### PR DESCRIPTION
Right now it's matching links even if they have garbage text in front of it. For example, `sahttp://www.google.com`

This change fixes that. Requiring the matching to start at the beginning of the string.