### PR TITLE
Allow @username for various commands

### DIFF
--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -74,7 +74,7 @@
         <file>avatars/pajlada.png</file>
         <file>images/download_update.png</file>
         <file>images/download_update_error.png</file>
-		<file>images/pajaDank.png</file>
+        <file>images/pajaDank.png</file>
     </qresource>
     <qresource prefix="/qt/etc">
         <file>qt.conf</file>

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -180,7 +180,7 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
-                auto target = words.at(1);
+                QString target;
 
                 if (words.at(1).at(0) == "@") {
                     target = words.at(1).mid(1);
@@ -207,7 +207,7 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
-                auto target = words.at(1);
+                QString target;
 
                 if (words.at(1).at(0) == "@") {
                     target = words.at(1).mid(1);
@@ -234,7 +234,7 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
-                auto target = words.at(1);
+                QString target;
 
                 if (words.at(1).at(0) == "@") {
                     target = words.at(1).mid(1);
@@ -269,7 +269,7 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
-                auto target = words.at(1);
+                QString target;
 
                 if (words.at(1).at(0) == "@") {
                     target = words.at(1).mid(1);

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -172,11 +172,21 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 channel->addMessage(Message::createSystemMessage(messageText));
 
                 return "";
-            } else if (commandName == "/ignore" && words.size() >= 2) {
+            } else if (commandName == "/ignore") {
+                if (words.size() < 2) {
+                    channel->addMessage(Message::createSystemMessage("Usage: /ignore [user]"));
+                    return "";
+                }
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
                 auto target = words.at(1);
+
+                if (words.at(1).at(0) == "@") {
+                    target = words.at(1).mid(1);
+                } else {
+                    target = words.at(1);
+                }
 
                 if (user->isAnon()) {
                     channel->addMessage(
@@ -189,11 +199,21 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
                 });
 
                 return "";
-            } else if (commandName == "/unignore" && words.size() >= 2) {
+            } else if (commandName == "/unignore") {
+                if (words.size() < 2) {
+                    channel->addMessage(Message::createSystemMessage("Usage: /unignore [user]"));
+                    return "";
+                }
                 auto app = getApp();
 
                 auto user = app->accounts->twitch.getCurrent();
                 auto target = words.at(1);
+
+                if (words.at(1).at(0) == "@") {
+                    target = words.at(1).mid(1);
+                } else {
+                    target = words.at(1);
+                }
 
                 if (user->isAnon()) {
                     channel->addMessage(
@@ -215,6 +235,12 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
 
                 auto user = app->accounts->twitch.getCurrent();
                 auto target = words.at(1);
+
+                if (words.at(1).at(0) == "@") {
+                    target = words.at(1).mid(1);
+                } else {
+                    target = words.at(1);
+                }
 
                 if (user->isAnon()) {
                     channel->addMessage(
@@ -244,6 +270,12 @@ QString CommandController::execCommand(const QString &text, ChannelPtr channel, 
 
                 auto user = app->accounts->twitch.getCurrent();
                 auto target = words.at(1);
+
+                if (words.at(1).at(0) == "@") {
+                    target = words.at(1).mid(1);
+                } else {
+                    target = words.at(1);
+                }
 
                 if (user->isAnon()) {
                     channel->addMessage(

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -130,7 +130,7 @@ void TwitchAccount::ignore(const QString &targetName,
         this->ignoreByID(targetUserId, targetName, onFinished);  //
     };
 
-    PartialTwitchUser::byName(this->userName_).getId(onIdFetched);
+    PartialTwitchUser::byName(targetName).getId(onIdFetched);
 }
 
 void TwitchAccount::ignoreByID(const QString &targetUserID, const QString &targetName,
@@ -197,7 +197,7 @@ void TwitchAccount::unignore(const QString &targetName,
         this->unignoreByID(targetUserId, targetName, onFinished);  //
     };
 
-    PartialTwitchUser::byName(this->userName_).getId(onIdFetched);
+    PartialTwitchUser::byName(targetName).getId(onIdFetched);
 }
 
 void TwitchAccount::unignoreByID(


### PR DESCRIPTION
Allow /ignore, /unignore, /follow, and /unfollow to use @ in front of username.