### PR TITLE
Fix QMenus from starting out of screen boundaries. Fixes #517 #571 #572

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1093,8 +1093,7 @@ void ChannelView::addContextMenuItems(const MessageLayoutElement *hoveredElement
     //            // insert into input
     //        });
 
-    menu->move(QCursor::pos());
-    menu->show();
+    menu->popup(QCursor::pos());
     menu->raise();
 
     return;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -56,9 +56,7 @@ SplitHeader::SplitHeader(Split *_split)
             QTimer::singleShot(80, this, [&, this] {
                 ChannelPtr _channel = this->split_->getChannel();
                 if (_channel->hasModRights()) {
-                    this->modeMenu_.move(
-                        this->modeButton_->mapToGlobal(QPoint(0, this->modeButton_->height())));
-                    this->modeMenu_.show();
+                    this->modeMenu_.popup(QCursor::pos());
                 }
             });
         });
@@ -83,9 +81,7 @@ SplitHeader::SplitHeader(Split *_split)
         this->addDropdownItems(dropdown.getElement());
         QObject::connect(dropdown.getElement(), &RippleEffectButton::leftMousePress, this, [this] {
             QTimer::singleShot(80, [&, this] {
-                this->dropdownMenu_.move(
-                    this->dropdownButton_->mapToGlobal(QPoint(0, this->dropdownButton_->height())));
-                this->dropdownMenu_.show();
+                this->dropdownMenu_.popup(QCursor::pos());
             });
         });
     }


### PR DESCRIPTION
Fixes issues where channel split header, right click menu, room options were showing up partially cut off by the screen when using them near the edge of the screen.

Fixes #517 
Fixes #571 
Fixes #572