### PR TITLE
Fix Global FFZ emotes in Emote Popup

### DIFF
--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -127,7 +127,7 @@ void EmotePopup::loadChannel(ChannelPtr _channel)
     // global
     addEmotes(*globalChannel, *twitchChannel->globalBttv().emotes(),
               "BetterTTV");
-    addEmotes(*globalChannel, *twitchChannel->globalBttv().emotes(),
+    addEmotes(*globalChannel, *twitchChannel->globalFfz().emotes(),
               "FrankerFaceZ");
 
     // channel


### PR DESCRIPTION
There was two instances of Global BTTV emotes in the Emote Popup global tab.
Changed the second instance to Global FFZ emotes.