### PR TITLE
Don't add empty messages to message history.

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -176,8 +176,9 @@ void SplitInput::installKeyPressedEvent()
             sendMessage = sendMessage.replace('\n', ' ');
 
             c->sendMessage(sendMessage);
-            // don't add duplicate messages to message history
-            if (this->prevMsg_.isEmpty() || !this->prevMsg_.endsWith(message))
+            // don't add duplicate messages and empty message to message history
+            if ((this->prevMsg_.isEmpty() || !this->prevMsg_.endsWith(message)) &&
+                !message.trimmed().isEmpty())
                 this->prevMsg_.append(message);
 
             event->accept();


### PR DESCRIPTION
I found out that if I just press 'Enter' (send empty message) or send messages with spaces, they will be stored in the message history.
I think it doesn't have to work that way.