### PR TITLE
Set displayName to UserInfo link as value.

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -438,7 +438,7 @@ void TwitchMessageBuilder::appendUsername()
         this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
                                    this->usernameColor_,
                                    FontStyle::ChatMediumBold)
-            ->setLink({Link::UserInfo, this->userName});
+            ->setLink({Link::UserInfo, this->message().displayName});
 
         auto currentUser = app->accounts->twitch.getCurrent();
 
@@ -464,7 +464,7 @@ void TwitchMessageBuilder::appendUsername()
         this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
                                    this->usernameColor_,
                                    FontStyle::ChatMediumBold)
-            ->setLink({Link::UserInfo, this->userName});
+            ->setLink({Link::UserInfo, this->message().displayName});
     }
 }
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -52,7 +52,7 @@ UserInfoPopup::UserInfoPopup()
         avatar->setScaleIndependantSize(100, 100);
         QObject::connect(avatar.getElement(), &Button::clicked, [this] {
             QDesktopServices::openUrl(
-                QUrl("https://twitch.tv/" + this->userName_));
+                QUrl("https://twitch.tv/" + this->userName_.toLower()));
         });
 
         // items on the right


### PR DESCRIPTION
This small change makes correct case of nicknames in UserInfoPopup window and right-click mentions.
At first I wanted to add some getDisplayName/setDisplayName methods, but then I realized there was easier way.
As far as I could see in code and test behaviour of program, it doesn't break anything.
 
![2018-08-22_13-44-25](https://user-images.githubusercontent.com/4051126/44459700-3e067480-a613-11e8-8fb7-f1927e224271.gif)
