### PR TITLE
Fixed double click in emote popup.

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1025,7 +1025,10 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             auto &link = hoveredElement->getLink();
             if (!getSettings()->linksDoubleClickOnly) {
                 this->handleLinkClick(event, link, layout);
+            }
 
+            // Invoke to signal from EmotePopup.
+            if (link.type == Link::InsertText) {
                 this->linkClicked.invoke(link);
             }
         } break;


### PR DESCRIPTION
At the moment, if `linksDoubleClickOnly` option is enabled, emotes from Emote Popup are not added to the input field.
At first sight it seems that line `this->linkClicked.invoke(link);` should be added to `mouseDoubleClickEvent` to fix problem.
But I think `linksDoubleClickOnly` should be ignored, because double click on emotes to add them is not obvious.