### PR TITLE
Added right-click on nickname to reply on whisper.

### DIFF
--- a/src/messages/Link.hpp
+++ b/src/messages/Link.hpp
@@ -13,6 +13,7 @@ public:
         UserInfo,
         UserTimeout,
         UserBan,
+        UserWhisper,
         InsertText,
         ShowMessage,
         UserAction,

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -438,7 +438,7 @@ void TwitchMessageBuilder::appendUsername()
         this->emplace<TextElement>(usernameText, MessageElementFlag::Username,
                                    this->usernameColor_,
                                    FontStyle::ChatMediumBold)
-            ->setLink({Link::UserInfo, this->message().displayName});
+            ->setLink({Link::UserWhisper, this->message().displayName});
 
         auto currentUser = app->accounts->twitch.getCurrent();
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1033,12 +1033,18 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
             }
         } break;
         case Qt::RightButton: {
+
+            auto insertText = [=](QString text) {
+                if (auto split = dynamic_cast<Split *>(this->parentWidget())) {
+                    split->insertTextToInput(text);
+                }
+            };
+
             auto &link = hoveredElement->getLink();
             if (link.type == Link::UserInfo) {
-                Split *split = dynamic_cast<Split *>(this->parentWidget());
-                if (split != nullptr) {
-                    split->insertTextToInput("@" + link.value + ", ");
-                }
+                insertText("@" + link.value + ", ");
+            } else if (link.type == Link::UserWhisper) {
+                insertText("/w " + link.value + " ");
             } else {
                 this->addContextMenuItems(hoveredElement, layout);
             }
@@ -1155,6 +1161,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
     }
 
     switch (link.type) {
+        case Link::UserWhisper:
         case Link::UserInfo: {
             auto user = link.value;
 


### PR DESCRIPTION
I improved work of the right click on nickname a little. 
Now, if you right click on user that whispered to you, `/w` is automatically added to input field to answer him.

![2018-08-26_01-51-06](https://user-images.githubusercontent.com/4051126/44623341-aa170000-a8d3-11e8-8614-433f8b47f20e.gif)

(And finally dynamic_cast is collapsed to condition!)