### PR TITLE
Added hotkey for Emote menu.

### DIFF
--- a/src/widgets/settingspages/KeyboardSettingsPage.cpp
+++ b/src/widgets/settingspages/KeyboardSettingsPage.cpp
@@ -41,6 +41,8 @@ KeyboardSettingsPage::KeyboardSettingsPage()
     form->addRow(new QLabel("Ctrl + R"), new QLabel("Change channel"));
     form->addRow(new QLabel("Ctrl + F"),
                  new QLabel("Search in current channel"));
+    form->addRow(new QLabel("Ctrl + E"),
+                 new QLabel("Open Emote menu"));
 }
 
 }  // namespace chatterino

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -289,7 +289,7 @@ void SplitInput::installKeyPressedEvent()
             }
         } else if (event->key() == Qt::Key_E &&
                    event->modifiers() == Qt::ControlModifier) {
-            openEmotePopup();
+            this->openEmotePopup();
         }
     });
 }

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -84,21 +84,7 @@ void SplitInput::initLayout()
     }));
 
     // open emote popup
-    QObject::connect(this->ui_.emoteButton, &EffectLabel::clicked, [this] {
-        if (!this->emotePopup_) {
-            this->emotePopup_ = std::make_unique<EmotePopup>();
-            this->emotePopup_->linkClicked.connect([this](const Link &link) {
-                if (link.type == Link::InsertText) {
-                    this->insertText(link.value + " ");
-                }
-            });
-        }
-
-        this->emotePopup_->resize(int(300 * this->emotePopup_->getScale()),
-                                  int(500 * this->emotePopup_->getScale()));
-        this->emotePopup_->loadChannel(this->split_->getChannel());
-        this->emotePopup_->show();
-    });
+    QObject::connect(this->ui_.emoteButton, &EffectLabel::clicked, [=] { this->openEmotePopup(); });
 
     // clear channelview selection when selecting in the input
     QObject::connect(this->ui_.textEdit, &QTextEdit::copyAvailable,
@@ -157,6 +143,23 @@ void SplitInput::updateEmoteButton()
 
     this->ui_.emoteButton->getLabel().setText(text);
     this->ui_.emoteButton->setFixedHeight(int(18 * scale));
+}
+
+void SplitInput::openEmotePopup()
+{
+    if (!this->emotePopup_) {
+        this->emotePopup_ = std::make_unique<EmotePopup>();
+        this->emotePopup_->linkClicked.connect([this](const Link &link) {
+            if (link.type == Link::InsertText) {
+                this->insertText(link.value + " ");
+            }
+        });
+    }
+
+    this->emotePopup_->resize(int(300 * this->emotePopup_->getScale()),
+                              int(500 * this->emotePopup_->getScale()));
+    this->emotePopup_->loadChannel(this->split_->getChannel());
+    this->emotePopup_->show();
 }
 
 void SplitInput::installKeyPressedEvent()
@@ -284,6 +287,9 @@ void SplitInput::installKeyPressedEvent()
                 this->split_->copyToClipboard();
                 event->accept();
             }
+        } else if (event->key() == Qt::Key_E &&
+                   event->modifiers() == Qt::ControlModifier) {
+            openEmotePopup();
         }
     });
 }

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -43,6 +43,7 @@ private:
     void initLayout();
     void installKeyPressedEvent();
     void updateEmoteButton();
+    void openEmotePopup();
 
     Split *const split_;
     std::shared_ptr<EmotePopup> emotePopup_;


### PR DESCRIPTION
I dunno why it hasn't been done yet, but I added hotkey `Ctrl+E` to open the Emote menu.
If I have option `Show input box when empty` disabled, then I can open the Emote menu only if I write something. If I want to send one smile, I need to insert space to see button for the Emote menu. 
So I think hotkey here is very suitable.

I hope you have nothing against adding hotkey.