### PR TITLE
Fixed down key in input field.

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -186,8 +186,7 @@ void SplitInput::installKeyPressedEvent()
                 this->currMsg_ = QString();
                 this->ui_.textEdit->setText(QString());
                 this->prevIndex_ = 0;
-            } else if (this->ui_.textEdit->toPlainText() ==
-                       this->prevMsg_.at(this->prevMsg_.size() - 1)) {
+            } else if (message == this->prevMsg_.at(this->prevMsg_.size() - 1)) {
                 this->prevMsg_.removeLast();
             }
             this->prevIndex_ = this->prevMsg_.size();
@@ -227,6 +226,13 @@ void SplitInput::installKeyPressedEvent()
                     page->selectNextSplit(SplitContainer::Below);
                 }
             } else {
+                // If user did not write anything before then just do nothing.
+                if (this->prevMsg_.isEmpty()) {
+                    return;
+                }
+                bool cursorToEnd = true;
+                QString message = ui_.textEdit->toPlainText();
+
                 if (this->prevIndex_ != (this->prevMsg_.size() - 1) &&
                     this->prevIndex_ != this->prevMsg_.size()) {
                     this->prevIndex_++;
@@ -234,12 +240,28 @@ void SplitInput::installKeyPressedEvent()
                         this->prevMsg_.at(this->prevIndex_));
                 } else {
                     this->prevIndex_ = this->prevMsg_.size();
-                    this->ui_.textEdit->setText(this->currMsg_);
+                    if (message == this->prevMsg_.at(this->prevIndex_ - 1)) {
+                        // If user has just come from a message history
+                        // Then simply get currMsg_.
+                        this->ui_.textEdit->setText(this->currMsg_);
+                    } else if (message != this->currMsg_) {
+                        // If user is already in current message 
+                        // And type something new
+                        // Then replace currMsg_ with new one.
+                        this->currMsg_ = message;
+                    } else {
+                        // If user is already in current message 
+                        // And no changed text
+                        // Then don't touch cursos.
+                        cursorToEnd = false;
+                    }
                 }
 
-                QTextCursor cursor = this->ui_.textEdit->textCursor();
-                cursor.movePosition(QTextCursor::End);
-                this->ui_.textEdit->setTextCursor(cursor);
+                if (cursorToEnd) {
+                    QTextCursor cursor = this->ui_.textEdit->textCursor();
+                    cursor.movePosition(QTextCursor::End);
+                    this->ui_.textEdit->setTextCursor(cursor);
+                }
             }
         } else if (event->key() == Qt::Key_Left) {
             if (event->modifiers() == Qt::AltModifier) {

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -245,16 +245,14 @@ void SplitInput::installKeyPressedEvent()
                         // Then simply get currMsg_.
                         this->ui_.textEdit->setText(this->currMsg_);
                     } else if (message != this->currMsg_) {
-                        // If user is already in current message 
+                        // If user are already in current message 
                         // And type something new
                         // Then replace currMsg_ with new one.
                         this->currMsg_ = message;
-                    } else {
-                        // If user is already in current message 
-                        // And no changed text
-                        // Then don't touch cursos.
-                        cursorToEnd = false;
                     }
+                    // If user is already in current message
+                    // Then don't touch cursos.
+                    cursorToEnd = (message == this->prevMsg_.at(this->prevIndex_ - 1));
                 }
 
                 if (cursorToEnd) {


### PR DESCRIPTION
At the moment, if user writes message and presses key down arrow, his message is simply erased without any chance of returning it.
`currMsg_` saves message only if user presses key up arrow.
If user types text, presses key up arrow, then key down arrow, everything is pretty fine.
But after this, if user appends message and presses key down arrow, message returns to its previous state.
So I fixed it and little improved work of key down arrow.

How it was:
![2018-08-27_21-32-07](https://user-images.githubusercontent.com/4051126/44678705-adc89500-aa41-11e8-816f-957e9f79bfad.gif)

How it's now:
![2018-08-27_21-34-58](https://user-images.githubusercontent.com/4051126/44678722-b9b45700-aa41-11e8-8fce-3f0029bbb511.gif)

