### PR TITLE
Clear highlights scrollbar with messages.

### DIFF
--- a/src/widgets/Scrollbar.cpp
+++ b/src/widgets/Scrollbar.cpp
@@ -55,6 +55,11 @@ void Scrollbar::unpauseHighlights()
     this->highlightsPaused_ = false;
 }
 
+void Scrollbar::clearHighlights()
+{
+    this->highlights_.clear();
+}
+
 LimitedQueueSnapshot<ScrollbarHighlight> Scrollbar::getHighlightSnapshot()
 {
     if (!this->highlightsPaused_) {

--- a/src/widgets/Scrollbar.hpp
+++ b/src/widgets/Scrollbar.hpp
@@ -27,6 +27,7 @@ public:
 
     void pauseHighlights();
     void unpauseHighlights();
+    void clearHighlights();
 
     void scrollToBottom(bool animate = false);
     bool isAtBottom() const;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -304,6 +304,7 @@ void ChannelView::clearMessages()
 {
     // Clear all stored messages in this chat widget
     this->messages.clear();
+    this->scrollBar_->clearHighlights();
 
     // Layout chat widget messages, and force an update regardless if there are
     // no messages


### PR DESCRIPTION
Every new feature must has issues. 
So "Clear messages" has one issue too! =)

If user has highlights in scrollbar, they will be shown even after the chat has been cleared.
So this PR just clears highlights in scrollbar with messages.

![2018-09-02_03-11-35](https://user-images.githubusercontent.com/4051126/44950931-89642280-ae5e-11e8-8662-a7dbb50455bc.gif)
