### PR TITLE
Added option of auto unshort links.

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -61,6 +61,12 @@ MessageElementFlags MessageElement::getFlags() const
     return this->flags_;
 }
 
+MessageElement *MessageElement::updateLink()
+{
+    this->linkChanged.invoke();
+    return this;
+}
+
 // IMAGE
 ImageElement::ImageElement(ImagePtr image, MessageElementFlags flags)
     : MessageElement(flags)
@@ -152,6 +158,15 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                               color, this->style_, container.getScale()))
                              ->setLink(this->getLink());
                 e->setTrailingSpace(trailingSpace);
+
+                // If URL link was changed, 
+                // Should update it in MessageLayoutElement too!
+                if (this->getLink().type == Link::Url) {
+                    this->linkChanged.connect(
+                        [this, e]() {
+                            e->setLink(this->getLink());
+                        });
+                }
                 return e;
             };
 

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <pajlada/signals/signalholder.hpp>
 
 namespace chatterino {
 class Channel;
@@ -128,6 +129,7 @@ public:
     const Link &getLink() const;
     bool hasTrailingSpace() const;
     MessageElementFlags getFlags() const;
+    MessageElement *updateLink();
 
     virtual void addToContainer(MessageLayoutContainer &container,
                                 MessageElementFlags flags) = 0;
@@ -135,6 +137,7 @@ public:
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
+    pajlada::Signals::NoArgSignal linkChanged;
 
 private:
     Link link_;

--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -22,10 +22,11 @@ void LinkResolver::getLinkInfo(const QString url,
         QString response = QString();
         if (statusCode == 200) {
             response = root.value("tooltip").toString();
+            url = root.value("link").toString();
         } else {
             response = root.value("message").toString();
         }
-        successCallback(QUrl::fromPercentEncoding(response.toUtf8()));
+        successCallback(QUrl::fromPercentEncoding(response.toUtf8()), url);
 
         return Success;
     });

--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -2,13 +2,14 @@
 
 #include "common/Common.hpp"
 #include "common/NetworkRequest.hpp"
+#include "messages/Link.hpp"
 
 #include <QString>
 
 namespace chatterino {
 
 void LinkResolver::getLinkInfo(const QString url,
-                           std::function<void(QString)> successCallback)
+                           std::function<void(QString, Link)> successCallback)
 {
     QString requestUrl("https://braize.pajlada.com/chatterino/link_resolver/" + 
         QUrl::toPercentEncoding(url, "", "/:"));
@@ -16,23 +17,24 @@ void LinkResolver::getLinkInfo(const QString url,
     NetworkRequest request(requestUrl);
     request.setCaller(QThread::currentThread());
     request.setTimeout(30000);
-    request.onSuccess([successCallback](auto result) mutable -> Outcome {
+    request.onSuccess([successCallback, url](auto result) mutable -> Outcome {
         auto root = result.parseJson();
         auto statusCode = root.value("status").toInt();
         QString response = QString();
+        QString linkString = url;
         if (statusCode == 200) {
             response = root.value("tooltip").toString();
-            url = root.value("link").toString();
+            linkString = root.value("link").toString();
         } else {
             response = root.value("message").toString();
         }
-        successCallback(QUrl::fromPercentEncoding(response.toUtf8()), url);
+        successCallback(QUrl::fromPercentEncoding(response.toUtf8()), Link(Link::Url, linkString));
 
         return Success;
     });
 
-    request.onError([successCallback](auto result) {
-        successCallback("No link info found");
+    request.onError([successCallback, url](auto result) {
+        successCallback("No link info found", Link(Link::Url, url));
 
         return true;
     });

--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -3,6 +3,7 @@
 #include "common/Common.hpp"
 #include "common/NetworkRequest.hpp"
 #include "messages/Link.hpp"
+#include "singletons/Settings.hpp"
 
 #include <QString>
 
@@ -24,7 +25,9 @@ void LinkResolver::getLinkInfo(const QString url,
         QString linkString = url;
         if (statusCode == 200) {
             response = root.value("tooltip").toString();
-            linkString = root.value("link").toString();
+            if (getSettings()->enableUnshortLinks) {
+                linkString = root.value("link").toString();
+            }
         } else {
             response = root.value("message").toString();
         }

--- a/src/providers/LinkResolver.hpp
+++ b/src/providers/LinkResolver.hpp
@@ -3,13 +3,15 @@
 #include <QString>
 #include <functional>
 
+#include "messages/Link.hpp"
+
 namespace chatterino {
 
 class LinkResolver
 {
 public:
     static void getLinkInfo(const QString url,
-                           std::function<void(QString)> callback);
+                           std::function<void(QString, Link)> callback);
 
 private:
 };

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -280,13 +280,16 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
                 ->setLink(link);
 
         LinkResolver::getLinkInfo(
-            linkString, [linkMELowercase, linkMEOriginal](QString tooltipText,
-                                                        Link originalLink) {
+            linkString, [linkMELowercase, linkMEOriginal, linkString]
+                            (QString tooltipText, Link originalLink) {
                 if (!tooltipText.isEmpty()) {
-                    linkMELowercase->setTooltip(tooltipText)
-                                    ->setLink(originalLink);
-                    linkMEOriginal->setTooltip(tooltipText)
-                                    ->setLink(originalLink);
+                    linkMELowercase->setTooltip(tooltipText);
+                    linkMEOriginal->setTooltip(tooltipText);
+                }
+                if (originalLink.value != linkString &&
+                    !originalLink.value.isEmpty()) {
+                    linkMELowercase->setLink(originalLink)->updateLink();
+                    linkMEOriginal->setLink(originalLink)->updateLink();
                 }
             });
     }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -281,7 +281,7 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
 
         LinkResolver::getLinkInfo(
             linkString, [linkMELowercase, linkMEOriginal](QString tooltipText,
-                                                        QString originalLink) {
+                                                        Link originalLink) {
                 if (!tooltipText.isEmpty()) {
                     linkMELowercase->setTooltip(tooltipText)
                                     ->setLink(originalLink);

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -280,10 +280,13 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
                 ->setLink(link);
 
         LinkResolver::getLinkInfo(
-            linkString, [linkMELowercase, linkMEOriginal](QString tooltipText) {
+            linkString, [linkMELowercase, linkMEOriginal](QString tooltipText,
+                                                        QString originalLink) {
                 if (!tooltipText.isEmpty()) {
-                    linkMELowercase->setTooltip(tooltipText);
-                    linkMEOriginal->setTooltip(tooltipText);
+                    linkMELowercase->setTooltip(tooltipText)
+                                    ->setLink(originalLink);
+                    linkMEOriginal->setTooltip(tooltipText)
+                                    ->setLink(originalLink);
                 }
             });
     }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -104,6 +104,7 @@ public:
     /// Links
     BoolSetting linksDoubleClickOnly = {"/links/doubleClickToOpen", false};
     BoolSetting enableLinkInfoTooltip = {"/links/linkInfoTooltip", false};
+    BoolSetting enableUnshortLinks = {"/links/unshortLinks", false};
     BoolSetting enableLowercaseLink = {"/links/linkLowercase", true};
 
     /// Ingored Users

--- a/src/widgets/settingspages/FeelPage.cpp
+++ b/src/widgets/settingspages/FeelPage.cpp
@@ -53,6 +53,9 @@ FeelPage::FeelPage()
         form->addRow("",
                      this->createCheckBox("Show link info in tooltips",
                                           getSettings()->enableLinkInfoTooltip));
+        form->addRow("",
+                     this->createCheckBox("Auto unshort links (requires restart)",
+                                          getSettings()->enableUnshortLinks));
     }
 
     layout->addSpacing(16);


### PR DESCRIPTION
**This PR is strongly related to this:** https://github.com/pajlada/chatterino-api-cache/pull/3

Thanks to the server side, the Chatterino 2 is able to get unshort links very easily.
So I added option, which replaces all short links with the original ones.
At the moment, I have made option to require client restart. 
Unfortunately, switching all links between short and unshort on runtime requires adding a lot of unwanted code, such methods `set/getOriginalLink()` in both `MessageLayoutElement\MessageElement` classes, variables `originalLink` and etc.

If you think this is wrong way to require restart, I'll keep working on it.

![screen3](https://user-images.githubusercontent.com/4051126/45169915-49f35880-b207-11e8-9707-30f20b77c288.gif)
