### PR TITLE
removed move semantics on append call

### DIFF
--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -55,7 +55,7 @@ public:
 
         auto unique = std::make_unique<T>(std::forward<Args>(args)...);
         auto pointer = unique.get();
-        this->append(std::move(unique));
+        this->append(unique);
         return pointer;
     }
 


### PR DESCRIPTION
minor change: append takes an lvalue so move semantics are never invoked (?)