### PR TITLE
Removed useless arg from appendTwitchEmote().

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -156,7 +156,7 @@ MessagePtr TwitchMessageBuilder::build()
         QStringList emoteString = iterator.value().toString().split('/');
 
         for (QString emote : emoteString) {
-            this->appendTwitchEmote(ircMessage, emote, twitchEmotes);
+            this->appendTwitchEmote(emote, twitchEmotes);
         }
 
         std::sort(
@@ -610,7 +610,7 @@ void TwitchMessageBuilder::parseHighlights(bool isPastMsg)
 }
 
 void TwitchMessageBuilder::appendTwitchEmote(
-    const Communi::IrcMessage *ircMessage, const QString &emote,
+    const QString &emote,
     std::vector<std::pair<int, EmotePtr>> &vec)
 {
     auto app = getApp();

--- a/src/providers/twitch/TwitchMessageBuilder.hpp
+++ b/src/providers/twitch/TwitchMessageBuilder.hpp
@@ -55,8 +55,7 @@ private:
     void appendUsername();
     void parseHighlights(bool isPastMsg);
 
-    void appendTwitchEmote(const Communi::IrcMessage *ircMessage,
-                           const QString &emote,
+    void appendTwitchEmote(const QString &emote,
                            std::vector<std::pair<int, EmotePtr>> &vec);
     Outcome tryAppendEmote(const EmoteName &name);
 


### PR DESCRIPTION
Can't figure out why `const Communi::IrcMessage *ircMessage` variable is passed, so I conclude that this is just a useless argument.