### PR TITLE
Dont add scrollbar highlights in /mentions.

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -437,7 +437,9 @@ void ChannelView::setChannel(ChannelPtr newChannel)
                 }
             }
 
-            this->scrollBar_->addHighlight(message->getScrollBarHighlight());
+            if (this->channel_->getType() != Channel::Type::TwitchMentions) {
+                this->scrollBar_->addHighlight(message->getScrollBarHighlight());
+            }
 
             this->messageWasAdded_ = true;
             this->layoutMessages();


### PR DESCRIPTION
Scrollbar highlights in `/mentions` tab is pretty useless thing. 
Any message that appears there will be highlighted on the scrollbar, so whole scrollbar is always red and it doesn't make sense.