### PR TITLE
Activate opened emote popup.

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -170,6 +170,7 @@ void SplitInput::openEmotePopup()
                               int(500 * this->emotePopup_->getScale()));
     this->emotePopup_->loadChannel(this->split_->getChannel());
     this->emotePopup_->show();
+    this->emotePopup_->activateWindow();
 }
 
 void SplitInput::installKeyPressedEvent()


### PR DESCRIPTION
This tiny PR fixes focus issue with opened Emote popup.

![2018-09-24_20-40-15](https://user-images.githubusercontent.com/4051126/45968768-8c57ca80-c03a-11e8-9cc4-6d9b14a61648.gif)
