### PR TITLE
Option to disable highlight of tab; disabled switching tabs by only right clicking

### DIFF
--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -68,7 +68,7 @@ NotebookTab::NotebookTab(Notebook *notebook)
     highlightNewMessagesAction->setChecked(true);
     QObject::connect(
         highlightNewMessagesAction, &QAction::triggered,
-        [this](bool checked) { this->highlightEnabled = checked; });
+        [this](bool checked) { this->highlightEnabled_ = checked; });
     this->menu_.addAction(highlightNewMessagesAction);
 }
 
@@ -170,7 +170,7 @@ void NotebookTab::setSelected(bool value)
 
 void NotebookTab::setHighlightState(HighlightState newHighlightStyle)
 {
-    if (this->isSelected() || !this->highlightEnabled) {
+    if (this->isSelected() || !this->highlightEnabled_) {
         return;
     }
     if (this->highlightState_ != HighlightState::Highlighted &&

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -357,12 +357,14 @@ bool NotebookTab::shouldDrawXButton()
 
 void NotebookTab::mousePressEvent(QMouseEvent *event)
 {
-    this->mouseDown_ = true;
-    this->mouseDownX_ = this->getXRect().contains(event->pos());
+    if (event->button() == Qt::LeftButton) {
+        this->mouseDown_ = true;
+        this->mouseDownX_ = this->getXRect().contains(event->pos());
 
-    this->update();
+        this->update();
 
-    this->notebook_->select(page);
+        this->notebook_->select(page);
+    }
 
     if (this->notebook_->getAllowUserTabManagement()) {
         switch (event->button()) {

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -62,12 +62,13 @@ NotebookTab::NotebookTab(Notebook *notebook)
     this->menu_.addAction("Close",
                           [=]() { this->notebook_->removePage(this->page); });
 
-    auto highlightNewMessagesAction = new QAction("Enable highlights on new messages", &this->menu_);
+    auto highlightNewMessagesAction =
+        new QAction("Enable highlights on new messages", &this->menu_);
     highlightNewMessagesAction->setCheckable(true);
     highlightNewMessagesAction->setChecked(true);
-    QObject::connect(highlightNewMessagesAction, &QAction::triggered, [this] (bool checked) {
-        this->highlightEnabled = checked;
-    });
+    QObject::connect(
+        highlightNewMessagesAction, &QAction::triggered,
+        [this](bool checked) { this->highlightEnabled = checked; });
     this->menu_.addAction(highlightNewMessagesAction);
 }
 

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -361,10 +361,10 @@ void NotebookTab::mousePressEvent(QMouseEvent *event)
         this->mouseDown_ = true;
         this->mouseDownX_ = this->getXRect().contains(event->pos());
 
-        this->update();
-
         this->notebook_->select(page);
     }
+
+    this->update();
 
     if (this->notebook_->getAllowUserTabManagement()) {
         switch (event->button()) {

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -62,12 +62,13 @@ NotebookTab::NotebookTab(Notebook *notebook)
     this->menu_.addAction("Close",
                           [=]() { this->notebook_->removePage(this->page); });
 
-    //    this->menu.addAction(enableHighlightsOnNewMessageAction);
-
-    //    QObject::connect(enableHighlightsOnNewMessageAction,
-    //    &QAction::toggled, [this](bool newValue) {
-    //        Log("New value is {}", newValue);  //
-    //    });
+    auto highlightNewMessagesAction = new QAction("Enable highlights on new messages", &this->menu_);
+    highlightNewMessagesAction->setCheckable(true);
+    highlightNewMessagesAction->setChecked(true);
+    QObject::connect(highlightNewMessagesAction, &QAction::triggered, [this] (bool checked) {
+        this->highlightEnabled = checked;
+    });
+    this->menu_.addAction(highlightNewMessagesAction);
 }
 
 void NotebookTab::themeChangedEvent()
@@ -168,7 +169,7 @@ void NotebookTab::setSelected(bool value)
 
 void NotebookTab::setHighlightState(HighlightState newHighlightStyle)
 {
-    if (this->isSelected()) {
+    if (this->isSelected() || !this->highlightEnabled) {
         return;
     }
     if (this->highlightState_ != HighlightState::Highlighted &&

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -82,7 +82,7 @@ private:
     bool mouseDownX_ = false;
 
     HighlightState highlightState_ = HighlightState::None;
-    bool highlightEnabled = true;
+    bool highlightEnabled_ = true;
 
     QMenu menu_;
 

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -82,6 +82,7 @@ private:
     bool mouseDownX_ = false;
 
     HighlightState highlightState_ = HighlightState::None;
+    bool highlightEnabled = true;
 
     QMenu menu_;
 


### PR DESCRIPTION
Implements a Chatterino 1 feature. This could also be saved in the settings as well but in my opinion it shouldn't. If that is something people want then I can implement it.
Also disables switching tabs if right clicking on another tab as that is just annoying if you don't want to switch tabs yet still want to change the tab highlighting rule.
Fixes #699 