### PR TITLE
Adds selecting the hovered word by double-clicking

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -162,8 +162,9 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 auto e = (new TextLayoutElement(
                               *this, text, QSize(width, metrics.height()),
                               color, this->style_, container.getScale()))
-                             ->setText(text);
+                             ->setLink(this->getLink());
                 e->setTrailingSpace(trailingSpace);
+                e->setText(text);
 
                 // If URL link was changed,
                 // Should update it in MessageLayoutElement too!

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -29,6 +29,12 @@ MessageElement *MessageElement::setLink(const Link &link)
     return this;
 }
 
+MessageElement *MessageElement::setText(const QString &text)
+{
+    this->text_ = text;
+    return this;
+}
+
 MessageElement *MessageElement::setTooltip(const QString &tooltip)
 {
     this->tooltip_ = tooltip;
@@ -156,16 +162,14 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 auto e = (new TextLayoutElement(
                               *this, text, QSize(width, metrics.height()),
                               color, this->style_, container.getScale()))
-                             ->setLink(this->getLink());
+                             ->setText(text);
                 e->setTrailingSpace(trailingSpace);
 
-                // If URL link was changed, 
+                // If URL link was changed,
                 // Should update it in MessageLayoutElement too!
                 if (this->getLink().type == Link::Url) {
                     this->linkChanged.connect(
-                        [this, e]() {
-                            e->setLink(this->getLink());
-                        });
+                        [this, e]() { e->setLink(this->getLink()); });
                 }
                 return e;
             };

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -11,8 +11,8 @@
 #include <boost/noncopyable.hpp>
 #include <cstdint>
 #include <memory>
-#include <vector>
 #include <pajlada/signals/signalholder.hpp>
+#include <vector>
 
 namespace chatterino {
 class Channel;
@@ -123,6 +123,7 @@ public:
     virtual ~MessageElement();
 
     MessageElement *setLink(const Link &link);
+    MessageElement *setText(const QString &text);
     MessageElement *setTooltip(const QString &tooltip);
     MessageElement *setTrailingSpace(bool value);
     const QString &getTooltip() const;
@@ -140,6 +141,7 @@ protected:
     pajlada::Signals::NoArgSignal linkChanged;
 
 private:
+    QString text_;
     Link link_;
     QString tooltip_;
     MessageElementFlags flags_;

--- a/src/messages/Selection.hpp
+++ b/src/messages/Selection.hpp
@@ -76,4 +76,14 @@ struct Selection {
     }
 };
 
+struct DoubleClickSelection {
+    int originalStart = 0;
+    int originalEnd = 0;
+    int origMessageIndex;
+    bool selectingLeft = false;
+    bool selectingRight = false;
+    SelectionItem origStartItem;
+    SelectionItem origEndItem;
+};
+
 }  // namespace chatterino

--- a/src/messages/layouts/MessageLayout.cpp
+++ b/src/messages/layouts/MessageLayout.cpp
@@ -278,6 +278,11 @@ int MessageLayout::getLastCharacterIndex() const
     return this->container_->getLastCharacterIndex();
 }
 
+int MessageLayout::getFirstMessageCharacterIndex() const
+{
+    return this->container_->getFirstMessageCharacterIndex();
+}
+
 int MessageLayout::getSelectionIndex(QPoint position)
 {
     return this->container_->getSelectionIndex(position);

--- a/src/messages/layouts/MessageLayout.hpp
+++ b/src/messages/layouts/MessageLayout.hpp
@@ -54,6 +54,7 @@ public:
     // Elements
     const MessageLayoutElement *getElementAt(QPoint point);
     int getLastCharacterIndex() const;
+    int getFirstMessageCharacterIndex() const;
     int getSelectionIndex(QPoint position);
     void addSelectionText(QString &str, int from = 0, int to = INT_MAX,
                           CopyMode copymode = CopyMode::Everything);

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -321,7 +321,7 @@ void MessageLayoutContainer::paintSelection(QPainter &painter, int messageIndex,
             int x = this->elements_[line.startIndex]->getRect().left();
             int r = this->elements_[line.endIndex - 1]->getRect().right();
 
-            if (line.endCharIndex < selection.selectionMin.charIndex) {
+            if (line.endCharIndex <= selection.selectionMin.charIndex) {
                 continue;
             }
 

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -516,8 +516,8 @@ int MessageLayoutContainer::getFirstMessageCharacterIndex() const
     // (no badges/timestamps/username)
     int index = 0;
     for (auto &element : this->elements_) {
-        if (element.get()->getFlags().hasAny(flags)) {
-            index += element.get()->getSelectionIndexCount();
+        if (element->getFlags().hasAny(flags)) {
+            index += element->getSelectionIndexCount();
         } else {
             break;
         }

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -485,7 +485,7 @@ int MessageLayoutContainer::getSelectionIndex(QPoint point)
         }
 
         // this is the word
-        if (point.x() < this->elements_[i]->getRect().right()) {
+        if (point.x() <= this->elements_[i]->getRect().right()) {
             index += this->elements_[i]->getMouseOverIndex(point);
             break;
         }

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -505,6 +505,26 @@ int MessageLayoutContainer::getLastCharacterIndex() const
     return this->lines_.back().endCharIndex;
 }
 
+int MessageLayoutContainer::getFirstMessageCharacterIndex() const
+{
+    static FlagsEnum<MessageElementFlag> flags;
+    flags.set(MessageElementFlag::Username);
+    flags.set(MessageElementFlag::Timestamp);
+    flags.set(MessageElementFlag::Badges);
+
+    // Get the index of the first character of the real message
+    // (no badges/timestamps/username)
+    int index = 0;
+    for (auto &element : this->elements_) {
+        if (element.get()->getFlags().hasAny(flags)) {
+            index += element.get()->getSelectionIndexCount();
+        } else {
+            break;
+        }
+    }
+    return index;
+}
+
 void MessageLayoutContainer::addSelectionText(QString &str, int from, int to,
                                               CopyMode copymode)
 {

--- a/src/messages/layouts/MessageLayoutContainer.hpp
+++ b/src/messages/layouts/MessageLayoutContainer.hpp
@@ -75,6 +75,7 @@ struct MessageLayoutContainer {
     // selection
     int getSelectionIndex(QPoint point);
     int getLastCharacterIndex() const;
+    int getFirstMessageCharacterIndex() const;
     void addSelectionText(QString &str, int from, int to, CopyMode copymode);
 
     bool isCollapsed();

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -58,9 +58,20 @@ MessageLayoutElement *MessageLayoutElement::setLink(const Link &_link)
     return this;
 }
 
+MessageLayoutElement *MessageLayoutElement::setText(const QString &_text)
+{
+    this->text_ = _text;
+    return this;
+}
+
 const Link &MessageLayoutElement::getLink() const
 {
     return this->link_;
+}
+
+const QString &MessageLayoutElement::getText() const
+{
+    return this->text_;
 }
 
 //
@@ -78,7 +89,8 @@ ImageLayoutElement::ImageLayoutElement(MessageElement &creator, ImagePtr image,
 void ImageLayoutElement::addCopyTextToString(QString &str, int from,
                                              int to) const
 {
-    const auto *emoteElement = dynamic_cast<EmoteElement *>(&this->getCreator());
+    const auto *emoteElement =
+        dynamic_cast<EmoteElement *>(&this->getCreator());
     if (emoteElement) {
         str += emoteElement->getEmote()->getCopyString();
         if (this->hasTrailingSpace()) {
@@ -87,7 +99,7 @@ void ImageLayoutElement::addCopyTextToString(QString &str, int from,
     }
 }
 
-int ImageLayoutElement::getSelectionIndexCount()
+int ImageLayoutElement::getSelectionIndexCount() const
 {
     return this->trailingSpace ? 2 : 1;
 }
@@ -120,7 +132,7 @@ void ImageLayoutElement::paintAnimated(QPainter &painter, int yOffset)
     }
 }
 
-int ImageLayoutElement::getMouseOverIndex(const QPoint &abs)
+int ImageLayoutElement::getMouseOverIndex(const QPoint &abs) const
 {
     return 0;
 }
@@ -162,7 +174,7 @@ void TextLayoutElement::addCopyTextToString(QString &str, int from,
     }
 }
 
-int TextLayoutElement::getSelectionIndexCount()
+int TextLayoutElement::getSelectionIndexCount() const
 {
     return this->text.length() + (this->trailingSpace ? 1 : 0);
 }
@@ -184,7 +196,7 @@ void TextLayoutElement::paintAnimated(QPainter &, int)
 {
 }
 
-int TextLayoutElement::getMouseOverIndex(const QPoint &abs)
+int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
 {
     if (abs.x() < this->getRect().left()) {
         return 0;
@@ -245,7 +257,7 @@ void TextIconLayoutElement::addCopyTextToString(QString &str, int from,
 {
 }
 
-int TextIconLayoutElement::getSelectionIndexCount()
+int TextIconLayoutElement::getSelectionIndexCount() const
 {
     return this->trailingSpace ? 2 : 1;
 }
@@ -280,7 +292,7 @@ void TextIconLayoutElement::paintAnimated(QPainter &painter, int yOffset)
 {
 }
 
-int TextIconLayoutElement::getMouseOverIndex(const QPoint &abs)
+int TextIconLayoutElement::getMouseOverIndex(const QPoint &abs) const
 {
     return 0;
 }

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -74,6 +74,11 @@ const QString &MessageLayoutElement::getText() const
     return this->text_;
 }
 
+FlagsEnum<MessageElementFlag> MessageLayoutElement::getFlags() const
+{
+    return this->creator_.getFlags();
+}
+
 //
 // IMAGE
 //
@@ -157,17 +162,17 @@ TextLayoutElement::TextLayoutElement(MessageElement &_creator, QString &_text,
                                      const QSize &_size, QColor _color,
                                      FontStyle _style, float _scale)
     : MessageLayoutElement(_creator, _size)
-    , text(_text)
     , color(_color)
     , style(_style)
     , scale(_scale)
 {
+    this->setText(_text);
 }
 
 void TextLayoutElement::addCopyTextToString(QString &str, int from,
                                             int to) const
 {
-    str += this->text.mid(from, to - from);
+    str += this->getText().mid(from, to - from);
 
     if (this->hasTrailingSpace()) {
         str += " ";
@@ -176,7 +181,7 @@ void TextLayoutElement::addCopyTextToString(QString &str, int from,
 
 int TextLayoutElement::getSelectionIndexCount() const
 {
-    return this->text.length() + (this->trailingSpace ? 1 : 0);
+    return this->getText().length() + (this->trailingSpace ? 1 : 0);
 }
 
 void TextLayoutElement::paint(QPainter &painter)
@@ -189,7 +194,7 @@ void TextLayoutElement::paint(QPainter &painter)
 
     painter.drawText(
         QRectF(this->getRect().x(), this->getRect().y(), 10000, 10000),
-        this->text, QTextOption(Qt::AlignLeft | Qt::AlignTop));
+        this->getText(), QTextOption(Qt::AlignLeft | Qt::AlignTop));
 }
 
 void TextLayoutElement::paintAnimated(QPainter &, int)
@@ -208,8 +213,8 @@ int TextLayoutElement::getMouseOverIndex(const QPoint &abs) const
 
     int x = this->getRect().left();
 
-    for (int i = 0; i < this->text.size(); i++) {
-        int w = metrics.width(this->text[i]);
+    for (int i = 0; i < this->getText().size(); i++) {
+        int w = metrics.width(this->getText()[i]);
 
         if (x + w > abs.x()) {
             return i;
@@ -229,10 +234,10 @@ int TextLayoutElement::getXFromIndex(int index)
 
     if (index <= 0) {
         return this->getRect().left();
-    } else if (index < this->text.size()) {
+    } else if (index < this->getText().size()) {
         int x = 0;
         for (int i = 0; i < index; i++) {
-            x += metrics.width(this->text[i]);
+            x += metrics.width(this->getText()[i]);
         }
         return x + this->getRect().left();
     } else {

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -30,20 +30,23 @@ public:
 
     MessageLayoutElement *setTrailingSpace(bool value);
     MessageLayoutElement *setLink(const Link &link_);
+    MessageLayoutElement *setText(const QString &text_);
 
     virtual void addCopyTextToString(QString &str, int from = 0,
                                      int to = INT_MAX) const = 0;
-    virtual int getSelectionIndexCount() = 0;
+    virtual int getSelectionIndexCount() const = 0;
     virtual void paint(QPainter &painter) = 0;
     virtual void paintAnimated(QPainter &painter, int yOffset) = 0;
-    virtual int getMouseOverIndex(const QPoint &abs) = 0;
+    virtual int getMouseOverIndex(const QPoint &abs) const = 0;
     virtual int getXFromIndex(int index) = 0;
     const Link &getLink() const;
+    const QString &getText() const;
 
 protected:
     bool trailingSpace = true;
 
 private:
+    QString text_;
     QRect rect_;
     Link link_;
     MessageElement &creator_;
@@ -59,10 +62,10 @@ public:
 protected:
     void addCopyTextToString(QString &str, int from = 0,
                              int to = INT_MAX) const override;
-    int getSelectionIndexCount() override;
+    int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
-    int getMouseOverIndex(const QPoint &abs) override;
+    int getMouseOverIndex(const QPoint &abs) const override;
     int getXFromIndex(int index) override;
 
 private:
@@ -80,10 +83,10 @@ public:
 protected:
     void addCopyTextToString(QString &str, int from = 0,
                              int to = INT_MAX) const override;
-    int getSelectionIndexCount() override;
+    int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
-    int getMouseOverIndex(const QPoint &abs) override;
+    int getMouseOverIndex(const QPoint &abs) const override;
     int getXFromIndex(int index) override;
 
 private:
@@ -104,10 +107,10 @@ public:
 protected:
     void addCopyTextToString(QString &str, int from = 0,
                              int to = INT_MAX) const override;
-    int getSelectionIndexCount() override;
+    int getSelectionIndexCount() const override;
     void paint(QPainter &painter) override;
     void paintAnimated(QPainter &painter, int yOffset) override;
-    int getMouseOverIndex(const QPoint &abs) override;
+    int getMouseOverIndex(const QPoint &abs) const override;
     int getXFromIndex(int index) override;
 
 private:

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -6,8 +6,10 @@
 #include <boost/noncopyable.hpp>
 #include <climits>
 
+#include "common/FlagsEnum.hpp"
 #include "messages/Link.hpp"
 #include "messages/MessageColor.hpp"
+#include "messages/MessageElement.hpp"
 
 class QPainter;
 
@@ -41,6 +43,7 @@ public:
     virtual int getXFromIndex(int index) = 0;
     const Link &getLink() const;
     const QString &getText() const;
+    FlagsEnum<MessageElementFlag> getFlags() const;
 
 protected:
     bool trailingSpace = true;
@@ -90,7 +93,6 @@ protected:
     int getXFromIndex(int index) override;
 
 private:
-    QString text;
     QColor color;
     FontStyle style;
     float scale;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -878,6 +878,94 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
         tooltipWidget->hide();
         return;
     }
+
+    if (this->isDoubleClick_) {
+        int wordStart;
+        int wordEnd;
+        this->getWordBounds(layout.get(), hoverLayoutElement, relativePos,
+                            wordStart, wordEnd);
+        SelectionItem newStart(messageIndex, wordStart);
+        SelectionItem newEnd(messageIndex, wordEnd);
+
+        // Selection changed in same message
+        if (messageIndex == this->dCSelection_.origMessageIndex) {
+            // Selecting to the left
+            if (wordStart < this->selection_.start.charIndex &&
+                !this->dCSelection_.selectingRight) {
+                this->dCSelection_.selectingLeft = true;
+                this->setSelection(newStart, this->selection_.end);
+                // Selecting to the right
+            } else if (wordEnd > this->selection_.end.charIndex &&
+                       !this->dCSelection_.selectingLeft) {
+                this->dCSelection_.selectingRight = true;
+                this->setSelection(this->selection_.start, newEnd);
+            }
+            // Swapping from selecting left to selecting right
+            if (wordStart > this->selection_.start.charIndex &&
+                !this->dCSelection_.selectingRight) {
+                if (wordStart > this->dCSelection_.originalEnd) {
+                    this->dCSelection_.selectingLeft = false;
+                    this->dCSelection_.selectingRight = true;
+                    this->setSelection(this->dCSelection_.origStartItem,
+                                       newEnd);
+                } else {
+                    this->setSelection(newStart, this->selection_.end);
+                }
+                // Swapping from selecting right to selecting left
+            } else if (wordEnd < this->selection_.end.charIndex &&
+                       !this->dCSelection_.selectingLeft) {
+                if (wordEnd < this->dCSelection_.originalStart) {
+                    this->dCSelection_.selectingLeft = true;
+                    this->dCSelection_.selectingRight = false;
+                    this->setSelection(newStart,
+                                       this->dCSelection_.origEndItem);
+                } else {
+                    this->setSelection(this->selection_.start, newEnd);
+                }
+            }
+            // Selection changed in a different message
+        } else {
+            // Message over the original
+            if (messageIndex < this->selection_.start.messageIndex) {
+                // Swapping from left to right selecting
+                if (!this->dCSelection_.selectingLeft) {
+                    this->dCSelection_.selectingLeft = true;
+                    this->dCSelection_.selectingRight = false;
+                }
+                if (wordStart < this->selection_.start.charIndex &&
+                    !this->dCSelection_.selectingRight) {
+                    this->dCSelection_.selectingLeft = true;
+                }
+                this->setSelection(newStart, this->dCSelection_.origEndItem);
+                // Message under the original
+            } else if (messageIndex > this->selection_.end.messageIndex) {
+                // Swapping from right to left selecting
+                if (!this->dCSelection_.selectingRight) {
+                    this->dCSelection_.selectingLeft = false;
+                    this->dCSelection_.selectingRight = true;
+                }
+                if (wordEnd > this->selection_.end.charIndex &&
+                    !this->dCSelection_.selectingLeft) {
+                    this->dCSelection_.selectingRight = true;
+                }
+                this->setSelection(this->dCSelection_.origStartItem, newEnd);
+                // Selection changed in non original message
+            } else {
+                if (this->dCSelection_.selectingLeft) {
+                    this->setSelection(newStart, this->selection_.end);
+                } else {
+                    this->setSelection(this->selection_.start, newEnd);
+                }
+            }
+        }
+        // Reset direction of selection
+        if (wordStart == this->dCSelection_.originalStart &&
+            wordEnd == this->dCSelection_.originalEnd) {
+            this->dCSelection_.selectingLeft =
+                this->dCSelection_.selectingRight = false;
+        }
+    }
+
     const auto &tooltip = hoverLayoutElement->getCreator().getTooltip();
     bool isLinkValid = hoverLayoutElement->getLink().isValid();
 
@@ -964,6 +1052,8 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
 {
     // check if mouse was pressed
     if (event->button() == Qt::LeftButton) {
+        this->isDoubleClick_ = this->dCSelection_.selectingLeft =
+            this->dCSelection_.selectingRight = false;
         if (this->isMouseDown_) {
             this->isMouseDown_ = false;
 
@@ -1188,23 +1278,24 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
         return;
     }
     if (!this->isMouseDown_) {
-        this->isMouseDown_ = true;
+        this->isDoubleClick_ = true;
 
-        const int mouseInWordIndex =
-            hoverLayoutElement->getMouseOverIndex(relativePos);
-        const int wordStart =
-            layout->getSelectionIndex(relativePos) - mouseInWordIndex;
-        const int selectionLength =
-            hoverLayoutElement->getSelectionIndexCount();
-        const int length = hoverLayoutElement->hasTrailingSpace()
-                               ? selectionLength - 1
-                               : selectionLength;
-        const int wordEnd = wordStart + length;
+        int wordStart;
+        int wordEnd;
+        this->getWordBounds(layout.get(), hoverLayoutElement, relativePos,
+                            wordStart, wordEnd);
 
         this->clickTimer_->start();
 
         SelectionItem wordMin(messageIndex, wordStart);
         SelectionItem wordMax(messageIndex, wordEnd);
+
+        this->dCSelection_.originalStart = wordStart;
+        this->dCSelection_.originalEnd = wordEnd;
+        this->dCSelection_.origMessageIndex = messageIndex;
+        this->dCSelection_.origStartItem = wordMin;
+        this->dCSelection_.origEndItem = wordMax;
+
         this->setSelection(wordMin, wordMax);
     }
 
@@ -1306,6 +1397,19 @@ void ChannelView::selectWholeMessage(MessageLayout *layout, int &messageIndex)
                            layout->getFirstMessageCharacterIndex());
     SelectionItem msgEnd(messageIndex, layout->getLastCharacterIndex());
     this->setSelection(msgStart, msgEnd);
+}
+
+void ChannelView::getWordBounds(MessageLayout *layout,
+                                const MessageLayoutElement *element,
+                                const QPoint &relativePos, int &wordStart,
+                                int &wordEnd)
+{
+    const int mouseInWordIndex = element->getMouseOverIndex(relativePos);
+    wordStart = layout->getSelectionIndex(relativePos) - mouseInWordIndex;
+    const int selectionLength = element->getSelectionIndexCount();
+    const int length =
+        element->hasTrailingSpace() ? selectionLength - 1 : selectionLength;
+    wordEnd = wordStart + length;
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1015,7 +1015,7 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     const MessageLayoutElement *hoverLayoutElement =
         layout->getElementAt(relativePos);
 
-    // Triple-click next to message selects whole message
+    // Triple-clicking a message selects the whole message
     if (this->clickTimer_->isActive() && this->selecting_) {
         this->selectWholeMessage(layout.get(), messageIndex);
     }
@@ -1194,7 +1194,12 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
             hoverLayoutElement->getMouseOverIndex(relativePos);
         const int wordStart =
             layout->getSelectionIndex(relativePos) - mouseInWordIndex;
-        const int wordEnd = wordStart + hoverLayoutElement->getText().length();
+        const int selectionLength =
+            hoverLayoutElement->getSelectionIndexCount();
+        const int length = hoverLayoutElement->hasTrailingSpace()
+                               ? selectionLength - 1
+                               : selectionLength;
+        const int wordEnd = wordStart + length;
 
         this->clickTimer_->start();
 

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -893,12 +893,22 @@ void ChannelView::mouseMoveEvent(QMouseEvent *event)
             if (wordStart < this->selection_.start.charIndex &&
                 !this->dCSelection_.selectingRight) {
                 this->dCSelection_.selectingLeft = true;
-                this->setSelection(newStart, this->selection_.end);
+                if (wordStart > this->dCSelection_.originalEnd) {
+                    this->setSelection(this->dCSelection_.origStartItem,
+                                       newEnd);
+                } else {
+                    this->setSelection(newStart, this->selection_.end);
+                }
                 // Selecting to the right
             } else if (wordEnd > this->selection_.end.charIndex &&
                        !this->dCSelection_.selectingLeft) {
                 this->dCSelection_.selectingRight = true;
-                this->setSelection(this->selection_.start, newEnd);
+                if (wordEnd < this->dCSelection_.originalStart) {
+                    this->setSelection(newStart,
+                                       this->dCSelection_.origEndItem);
+                } else {
+                    this->setSelection(this->selection_.start, newEnd);
+                }
             }
             // Swapping from selecting left to selecting right
             if (wordStart > this->selection_.start.charIndex &&

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -120,6 +120,10 @@ ChannelView::ChannelView(BaseWidget *parent)
     QObject::connect(shortcut, &QShortcut::activated, [this] {
         QGuiApplication::clipboard()->setText(this->getSelectedText());
     });
+
+    this->clickTimer_ = new QTimer(this);
+    this->clickTimer_->setSingleShot(true);
+    this->clickTimer_->setInterval(500);
 }
 
 void ChannelView::initializeLayout()
@@ -1017,12 +1021,13 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     }
 
     // handle the click
-    this->handleMouseClick(event, hoverLayoutElement, layout.get());
+    this->handleMouseClick(event, hoverLayoutElement, layout.get(),
+                           messageIndex);
 }
 
 void ChannelView::handleMouseClick(QMouseEvent *event,
                                    const MessageLayoutElement *hoveredElement,
-                                   MessageLayout *layout)
+                                   MessageLayout *layout, int &messageIndex)
 {
     switch (event->button()) {
         case Qt::LeftButton: {
@@ -1030,6 +1035,16 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
                 if (this->messagesAddedSinceSelectionPause_ >
                     SELECTION_RESUME_SCROLLING_MSG_THRESHOLD) {
                     this->showingLatestMessages_ = false;
+                }
+
+                if (this->clickTimer_->isActive()) {
+                    auto firstRealCharacterIndex =
+                        layout->getFirstMessageCharacterIndex();
+                    SelectionItem msgStart(messageIndex,
+                                           firstRealCharacterIndex);
+                    SelectionItem msgEnd(messageIndex,
+                                         layout->getLastCharacterIndex());
+                    this->setSelection(msgStart, msgEnd);
                 }
 
                 // this->pausedBySelection = false;
@@ -1184,6 +1199,8 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
         const int wordStart =
             layout->getSelectionIndex(relativePos) - mouseInWordIndex;
         const int wordEnd = wordStart + hoverLayoutElement->getText().length();
+
+        this->clickTimer_->start();
 
         SelectionItem wordMin(messageIndex, wordStart);
         SelectionItem wordMax(messageIndex, wordEnd);

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -945,7 +945,6 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
             }
 
             int index = layout->getSelectionIndex(relativePos);
-
             auto selectionItem = SelectionItem(messageIndex, index);
             this->setSelection(selectionItem, selectionItem);
         } break;
@@ -1016,18 +1015,22 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     const MessageLayoutElement *hoverLayoutElement =
         layout->getElementAt(relativePos);
 
+    // Triple-click next to message selects whole message
+    if (this->clickTimer_->isActive() && this->selecting_) {
+        this->selectWholeMessage(layout.get(), messageIndex);
+    }
+
     if (hoverLayoutElement == nullptr) {
         return;
     }
 
     // handle the click
-    this->handleMouseClick(event, hoverLayoutElement, layout.get(),
-                           messageIndex);
+    this->handleMouseClick(event, hoverLayoutElement, layout.get());
 }
 
 void ChannelView::handleMouseClick(QMouseEvent *event,
                                    const MessageLayoutElement *hoveredElement,
-                                   MessageLayout *layout, int &messageIndex)
+                                   MessageLayout *layout)
 {
     switch (event->button()) {
         case Qt::LeftButton: {
@@ -1035,16 +1038,6 @@ void ChannelView::handleMouseClick(QMouseEvent *event,
                 if (this->messagesAddedSinceSelectionPause_ >
                     SELECTION_RESUME_SCROLLING_MSG_THRESHOLD) {
                     this->showingLatestMessages_ = false;
-                }
-
-                if (this->clickTimer_->isActive()) {
-                    auto firstRealCharacterIndex =
-                        layout->getFirstMessageCharacterIndex();
-                    SelectionItem msgStart(messageIndex,
-                                           firstRealCharacterIndex);
-                    SelectionItem msgEnd(messageIndex,
-                                         layout->getLastCharacterIndex());
-                    this->setSelection(msgStart, msgEnd);
                 }
 
                 // this->pausedBySelection = false;
@@ -1189,6 +1182,9 @@ void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
         layout->getElementAt(relativePos);
 
     if (hoverLayoutElement == nullptr) {
+        // Possibility for triple click which doesn't have to be over an
+        // existing layout element
+        this->clickTimer_->start();
         return;
     }
     if (!this->isMouseDown_) {
@@ -1297,6 +1293,14 @@ int ChannelView::getLayoutWidth() const
         return int(this->width() - 8 * this->getScale());
 
     return this->width();
+}
+
+void ChannelView::selectWholeMessage(MessageLayout *layout, int &messageIndex)
+{
+    SelectionItem msgStart(messageIndex,
+                           layout->getFirstMessageCharacterIndex());
+    SelectionItem msgEnd(messageIndex, layout->getLastCharacterIndex());
+    this->setSelection(msgStart, msgEnd);
 }
 
 }  // namespace chatterino

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1012,7 +1012,6 @@ void ChannelView::mousePressEvent(QMouseEvent *event)
 
     if (!tryGetMessageAt(event->pos(), layout, relativePos, messageIndex)) {
         setCursor(Qt::ArrowCursor);
-
         auto messagesSnapshot = this->getMessagesSnapshot();
         if (messagesSnapshot.getLength() == 0) {
             return;
@@ -1066,18 +1065,19 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         this->dCSelection_.selectingLeft = this->dCSelection_.selectingRight =
             false;
-        if (this->isMouseDown_) {
-            this->isMouseDown_ = false;
-
-            if (fabsf(distanceBetweenPoints(this->lastPressPosition_,
-                                            event->screenPos())) > 15.f) {
-                return;
-            }
-        } else if (this->isDoubleClick_) {
+        if (this->isDoubleClick_) {
             this->isDoubleClick_ = false;
             // Was actually not a wanted triple-click
             if (fabsf(distanceBetweenPoints(this->lastDClickPosition_,
                                             event->screenPos())) > 10.f) {
+                this->clickTimer_->stop();
+                return;
+            }
+        } else if (this->isMouseDown_) {
+            this->isMouseDown_ = false;
+
+            if (fabsf(distanceBetweenPoints(this->lastPressPosition_,
+                                            event->screenPos())) > 15.f) {
                 return;
             }
         } else {
@@ -1098,7 +1098,6 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
         // not left or right button
         return;
     }
-
     // find message
     this->layoutMessages();
 
@@ -1123,10 +1122,12 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
 
     const MessageLayoutElement *hoverLayoutElement =
         layout->getElementAt(relativePos);
-
     // Triple-clicking a message selects the whole message
     if (this->clickTimer_->isActive() && this->selecting_) {
-        this->selectWholeMessage(layout.get(), messageIndex);
+        if (fabsf(distanceBetweenPoints(this->lastDClickPosition_,
+                                        event->screenPos())) < 10.f) {
+            this->selectWholeMessage(layout.get(), messageIndex);
+        }
     }
 
     if (hoverLayoutElement == nullptr) {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1066,14 +1066,15 @@ void ChannelView::mouseReleaseEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         this->dCSelection_.selectingLeft = this->dCSelection_.selectingRight =
             false;
-        if (this->isMouseDown_ || this->isDoubleClick_) {
+        if (this->isMouseDown_) {
             this->isMouseDown_ = false;
-            this->isDoubleClick_ = false;
 
             if (fabsf(distanceBetweenPoints(this->lastPressPosition_,
                                             event->screenPos())) > 15.f) {
                 return;
             }
+        } else if (this->isDoubleClick_) {
+            this->isDoubleClick_ = false;
             // Was actually not a wanted triple-click
             if (fabsf(distanceBetweenPoints(this->lastDClickPosition_,
                                             event->screenPos())) > 10.f) {

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -26,6 +26,7 @@
 #include <QDebug>
 #include <QDesktopServices>
 #include <QGraphicsBlurEffect>
+#include <QMessageBox>
 #include <QPainter>
 
 #include <algorithm>
@@ -1156,27 +1157,40 @@ void ChannelView::addContextMenuItems(
 
 void ChannelView::mouseDoubleClickEvent(QMouseEvent *event)
 {
+    std::shared_ptr<MessageLayout> layout;
+    QPoint relativePos;
+    int messageIndex;
+
+    if (!tryGetMessageAt(event->pos(), layout, relativePos, messageIndex)) {
+        return;
+    }
+
+    // message under cursor is collapsed
+    if (layout->flags.has(MessageLayoutFlag::Collapsed)) {
+        return;
+    }
+
+    const MessageLayoutElement *hoverLayoutElement =
+        layout->getElementAt(relativePos);
+
+    if (hoverLayoutElement == nullptr) {
+        return;
+    }
+    if (!this->isMouseDown_) {
+        this->isMouseDown_ = true;
+
+        const int mouseInWordIndex =
+            hoverLayoutElement->getMouseOverIndex(relativePos);
+        const int wordStart =
+            layout->getSelectionIndex(relativePos) - mouseInWordIndex;
+        const int wordEnd = wordStart + hoverLayoutElement->getText().length();
+
+        SelectionItem wordMin(messageIndex, wordStart);
+        SelectionItem wordMax(messageIndex, wordEnd);
+        this->setSelection(wordMin, wordMax);
+    }
+
     if (getSettings()->linksDoubleClickOnly) {
-        std::shared_ptr<MessageLayout> layout;
-        QPoint relativePos;
-        int messageIndex;
-
-        if (!tryGetMessageAt(event->pos(), layout, relativePos, messageIndex)) {
-            return;
-        }
-
-        // message under cursor is collapsed
-        if (layout->flags.has(MessageLayoutFlag::Collapsed)) {
-            return;
-        }
-
-        const MessageLayoutElement *hoverLayoutElement =
-            layout->getElementAt(relativePos);
-
-        if (hoverLayoutElement == nullptr) {
-            return;
-        }
-
         auto &link = hoverLayoutElement->getLink();
         this->handleLinkClick(event, link, layout.get());
     }

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -154,6 +154,7 @@ private:
     DoubleClickSelection dCSelection_;
     QPointF lastPressPosition_;
     QPointF lastRightPressPosition_;
+    QPointF lastDClickPosition_;
     QTimer *clickTimer_;
 
     Selection selection_;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -105,6 +105,9 @@ private:
     MessageElementFlags getFlags() const;
     bool isPaused();
     void selectWholeMessage(MessageLayout *layout, int &messageIndex);
+    void getWordBounds(MessageLayout *layout,
+                       const MessageLayoutElement *element,
+                       const QPoint &relativePos, int &wordStart, int &wordEnd);
 
     void handleMouseClick(QMouseEvent *event,
                           const MessageLayoutElement *hoverLayoutElement,
@@ -147,6 +150,8 @@ private:
     // Mouse event variables
     bool isMouseDown_ = false;
     bool isRightMouseDown_ = false;
+    bool isDoubleClick_ = false;
+    DoubleClickSelection dCSelection_;
     QPointF lastPressPosition_;
     QPointF lastRightPressPosition_;
     QTimer *clickTimer_;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -104,10 +104,11 @@ private:
     void setSelection(const SelectionItem &start, const SelectionItem &end);
     MessageElementFlags getFlags() const;
     bool isPaused();
+    void selectWholeMessage(MessageLayout *layout, int &messageIndex);
 
     void handleMouseClick(QMouseEvent *event,
                           const MessageLayoutElement *hoverLayoutElement,
-                          MessageLayout *layout, int &messageIndex);
+                          MessageLayout *layout);
     void addContextMenuItems(const MessageLayoutElement *hoveredElement,
                              MessageLayout *layout);
     int getLayoutWidth() const;

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -107,7 +107,7 @@ private:
 
     void handleMouseClick(QMouseEvent *event,
                           const MessageLayoutElement *hoverLayoutElement,
-                          MessageLayout *layout);
+                          MessageLayout *layout, int &messageIndex);
     void addContextMenuItems(const MessageLayoutElement *hoveredElement,
                              MessageLayout *layout);
     int getLayoutWidth() const;
@@ -148,6 +148,7 @@ private:
     bool isRightMouseDown_ = false;
     QPointF lastPressPosition_;
     QPointF lastRightPressPosition_;
+    QTimer *clickTimer_;
 
     Selection selection_;
     bool selecting_ = false;


### PR DESCRIPTION
Also fixes an unrelated bug(was already happening in earlier versions) which messed up the drawing of the selection box as seen in [this gif](https://i.imgur.com/7Ka2NFO.gifv).
Fixes #559 