### PR TITLE
add menu option to reload subscriber emotes

### DIFF
--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -230,6 +230,7 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
 
     menu->addSeparator();
     menu->addAction("Reload channel emotes", this, SLOT(reloadChannelEmotes()));
+    menu->addAction("Reload subscriber emotes", this, SLOT(reloadSubscriberEmotes()));
     menu->addAction("Reconnect", this, SLOT(reconnect()));
     menu->addAction("Clear messages", this->split_, &Split::clear);
     //    menu->addSeparator();
@@ -537,6 +538,11 @@ void SplitHeader::reloadChannelEmotes()
 
     if (auto twitchChannel = dynamic_cast<TwitchChannel *>(channel.get()))
         twitchChannel->refreshChannelEmotes();
+}
+
+void SplitHeader::reloadSubscriberEmotes()
+{
+    getApp()->accounts->twitch.getCurrent()->loadEmotes();
 }
 
 void SplitHeader::reconnect()

--- a/src/widgets/splits/SplitHeader.hpp
+++ b/src/widgets/splits/SplitHeader.hpp
@@ -75,6 +75,7 @@ private:
 public slots:
     void moveSplit();
     void reloadChannelEmotes();
+    void reloadSubscriberEmotes();
     void reconnect();
 };
 


### PR DESCRIPTION
So basically the `loadEmotes` function from twitchaccount seems perfectly capable of reloading all the subscriber emotes long after init, it even clears the list nicely, its just never done in the current program. This pr just adds a convenient button for it under reload channel emotes.

From my brief testing it seems to work perfectly fine and doesn't break anything, quite convenient for gift subs nanHead