### PR TITLE
fixed regex to display links with port correctly

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -447,7 +447,7 @@ void TwitchMessageBuilder::addTextOrEmoji(const QString &string_)
         }
     } else {
         static QRegularExpression domainRegex(
-            R"(^(?:(?:ftp|http)s?:\/\/)?([^\/:]+)(?:\/.*)?$)",
+            R"(^(?:(?:ftp|http)s?:\/\/)?([^\/]+)(?:\/.*)?$)",
             QRegularExpression::CaseInsensitiveOption);
 
         QString lowercaseLinkString;


### PR DESCRIPTION
changed the regex to allow for port-numbers in the url, fixes #762 