### PR TITLE
added winapi-call to flush clipboard

### DIFF
--- a/src/RunGui.cpp
+++ b/src/RunGui.cpp
@@ -11,6 +11,10 @@
 #include "singletons/Updates.hpp"
 #include "widgets/dialogs/LastRunCrashDialog.hpp"
 
+#ifdef USEWINSDK
+#    include "util/WindowsHelper.hpp"
+#endif
+
 #ifdef C_USE_BREAKPAD
 #    include <QBreakpadHandler.h>
 #endif
@@ -132,6 +136,11 @@ void runGui(QApplication &a, Paths &paths, Settings &settings)
     pajlada::Settings::SettingManager::gSave();
 
     chatterino::NetworkManager::deinit();
+
+#ifdef USEWINSDK
+	// flushing windows clipboard to keep copied messages
+    flushClipboard();
+#endif
 
     _exit(0);
 }

--- a/src/util/WindowsHelper.cpp
+++ b/src/util/WindowsHelper.cpp
@@ -34,6 +34,18 @@ boost::optional<UINT> getWindowDpi(HWND hwnd)
     return boost::none;
 }
 
+typedef HRESULT(CALLBACK *OleFlushClipboard_)();
+
+void flushClipboard()
+{
+    static HINSTANCE ole32 = LoadLibrary(L"Ole32.dll");
+    if (ole32 != nullptr) {
+        if (auto oleFlushClipboard = OleFlushClipboard_(GetProcAddress(ole32, "OleFlushClipboard"))) {
+            oleFlushClipboard();
+        }
+    }
+}
+
 }  // namespace chatterino
 
 #endif

--- a/src/util/WindowsHelper.hpp
+++ b/src/util/WindowsHelper.hpp
@@ -8,6 +8,8 @@
 namespace chatterino {
 
 boost::optional<UINT> getWindowDpi(HWND hwnd);
+void flushClipboard();
+
 
 }  // namespace chatterino
 


### PR DESCRIPTION
Added a winapi-call to OleFlushClipboard before exiting the application. This fixes #639 

I don't know if the call is on the right location in `RunGui.cpp` - maybe there's a better function that gets triggered before exiting chatterino?