### PR TITLE
Return previous state of tab when channel go offline.

### DIFF
--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -18,6 +18,7 @@ enum class HighlightState {
     Highlighted,
     NewMessage,
     Notification,
+    Offline,
 };
 
 inline QString qS(const std::string &string)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -419,6 +419,8 @@ void TwitchChannel::setLive(bool newLiveStatus)
                 auto offline =
                     makeSystemMessage(this->getName() + " is offline");
                 this->addMessage(offline);
+                this->tabHighlightRequested.invoke(
+                    HighlightState::Offline);
             }
             guard->live = newLiveStatus;
         }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -555,7 +555,7 @@ void ChannelView::setChannel(ChannelPtr newChannel)
     TwitchChannel *tc = dynamic_cast<TwitchChannel *>(newChannel.get());
     if (tc != nullptr) {
         tc->tabHighlightRequested.connect([this](HighlightState state) {
-            this->tabHighlightRequested.invoke(HighlightState::Notification);
+            this->tabHighlightRequested.invoke(state);
         });
     }
 }

--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -164,6 +164,7 @@ void NotebookTab::setSelected(bool value)
     this->selected_ = value;
 
     this->highlightState_ = HighlightState::None;
+    this->lastHighlightState_ = HighlightState::None;
 
     this->update();
 }
@@ -178,6 +179,13 @@ void NotebookTab::setHighlightState(HighlightState newHighlightStyle)
         this->highlightState_ = newHighlightStyle;
 
         this->update();
+    } else if (newHighlightStyle == HighlightState::Offline) {
+        this->highlightState_ = this->lastHighlightState_;
+        this->update();
+    }
+
+    if (newHighlightStyle != HighlightState::Notification) {
+        this->lastHighlightState_ = newHighlightStyle;
     }
 }
 

--- a/src/widgets/helper/NotebookTab.hpp
+++ b/src/widgets/helper/NotebookTab.hpp
@@ -85,6 +85,7 @@ private:
     bool mouseDownX_ = false;
 
     HighlightState highlightState_ = HighlightState::None;
+    HighlightState lastHighlightState_ = HighlightState::None;
     bool highlightEnabled_ = true;
     QAction *highlightNewMessagesAction_;
 


### PR DESCRIPTION
I think this is pretty wrong to have "online" state of tab even if channel went offline already.
So this PR saves not displayed state in `lastHighlightState_` and takes state from this variable when the channel becomes offline.