### PR TITLE
ClosedSplits feature (ctrl+shift+t in browsers)

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -261,7 +261,8 @@ SOURCES += \
     src/messages/MessageContainer.cpp \
     src/debug/Benchmark.cpp \
     src/common/UsernameSet.cpp \
-    src/widgets/settingspages/AdvancedPage.cpp
+    src/widgets/settingspages/AdvancedPage.cpp \
+    src/widgets/splits/ClosedSplits.cpp
 
 HEADERS  += \
     src/Application.hpp \
@@ -462,7 +463,8 @@ HEADERS  += \
     src/widgets/helper/Button.hpp \
     src/messages/MessageContainer.hpp \
     src/common/UsernameSet.hpp \
-    src/widgets/settingspages/AdvancedPage.hpp
+    src/widgets/settingspages/AdvancedPage.hpp \
+    src/widgets/splits/ClosedSplits.hpp
 
 RESOURCES += \
     resources/resources.qrc \

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -15,8 +15,10 @@
 #include "widgets/dialogs/UpdateDialog.hpp"
 #include "widgets/dialogs/WelcomeDialog.hpp"
 #include "widgets/helper/EffectLabel.hpp"
+#include "widgets/helper/NotebookTab.hpp"
 #include "widgets/helper/Shortcut.hpp"
 #include "widgets/helper/TitlebarButton.hpp"
+#include "widgets/splits/ClosedSplits.hpp"
 #include "widgets/splits/Split.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 
@@ -304,6 +306,26 @@ void Window::addShortcuts()
     // Close tab
     createWindowShortcut(this, "CTRL+SHIFT+W",
                          [this] { this->notebook_->removeCurrentPage(); });
+
+    // Reopen last closed split
+    createWindowShortcut(this, "CTRL+G", [this] {
+        if (ClosedSplits::empty()) {
+            return;
+        }
+        ClosedSplits::SplitInfo si = ClosedSplits::pop();
+        SplitContainer *splitContainer{nullptr};
+        if (si.tab) {
+            splitContainer = dynamic_cast<SplitContainer *>(si.tab->page);
+        }
+        if (!splitContainer) {
+            splitContainer = this->notebook_->getOrAddSelectedPage();
+        }
+        this->notebook_->select(splitContainer);
+        Split *split = new Split(splitContainer);
+        splitContainer->appendSplit(split);
+        split->setChannel(
+            getApp()->twitch.server->getOrAddChannel(si.channelName));
+    });
 }
 
 #define UGLYMACROHACK1(s) #s

--- a/src/widgets/Window.cpp
+++ b/src/widgets/Window.cpp
@@ -322,9 +322,9 @@ void Window::addShortcuts()
         }
         this->notebook_->select(splitContainer);
         Split *split = new Split(splitContainer);
-        splitContainer->appendSplit(split);
         split->setChannel(
             getApp()->twitch.server->getOrAddChannel(si.channelName));
+        splitContainer->appendSplit(split);
     });
 }
 

--- a/src/widgets/splits/ClosedSplits.cpp
+++ b/src/widgets/splits/ClosedSplits.cpp
@@ -1,0 +1,52 @@
+#include "ClosedSplits.hpp"
+
+namespace chatterino {
+
+std::mutex ClosedSplits::m_;
+std::vector<ClosedSplits::SplitInfo> ClosedSplits::closedSplits_;
+
+void ClosedSplits::invalidateTab(NotebookTab *const tab)
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    auto it = std::find_if(
+        ClosedSplits::closedSplits_.begin(), ClosedSplits::closedSplits_.end(),
+        [tab](const auto &item) -> bool { return item.tab == tab; });
+    if (it == ClosedSplits::closedSplits_.end()) {
+        return;
+    }
+    it->tab = nullptr;
+}
+
+void ClosedSplits::push(const SplitInfo &si)
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    ClosedSplits::closedSplits_.push_back(si);
+}
+
+void ClosedSplits::push(SplitInfo &&si)
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    ClosedSplits::closedSplits_.push_back(std::move(si));
+}
+
+ClosedSplits::SplitInfo ClosedSplits::pop()
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    SplitInfo si = std::move(ClosedSplits::closedSplits_.back());
+    ClosedSplits::closedSplits_.pop_back();
+    return si;
+}
+
+bool ClosedSplits::empty()
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    return ClosedSplits::closedSplits_.empty();
+}
+
+std::size_t ClosedSplits::size()
+{
+    std::lock_guard<std::mutex> lk(ClosedSplits::m_);
+    return ClosedSplits::closedSplits_.size();
+}
+
+}  // namespace chatterino

--- a/src/widgets/splits/ClosedSplits.hpp
+++ b/src/widgets/splits/ClosedSplits.hpp
@@ -1,5 +1,4 @@
-#ifndef CLOSEDSPLITS_HPP
-#define CLOSEDSPLITS_HPP
+#pragma once
 
 #include "common/Channel.hpp"
 #include "widgets/helper/NotebookTab.hpp"
@@ -31,5 +30,3 @@ private:
 };
 
 }  // namespace chatterino
-
-#endif  // CLOSEDSPLITS_HPP

--- a/src/widgets/splits/ClosedSplits.hpp
+++ b/src/widgets/splits/ClosedSplits.hpp
@@ -1,0 +1,35 @@
+#ifndef CLOSEDSPLITS_HPP
+#define CLOSEDSPLITS_HPP
+
+#include "common/Channel.hpp"
+#include "widgets/helper/NotebookTab.hpp"
+
+#include <deque>
+#include <mutex>
+#include <utility>
+
+namespace chatterino {
+
+class ClosedSplits
+{
+public:
+    struct SplitInfo {
+        QString channelName;
+        NotebookTab *tab;  // non owning ptr
+    };
+
+    static void invalidateTab(NotebookTab *const tab);
+    static void push(const SplitInfo &si);
+    static void push(SplitInfo &&si);
+    static SplitInfo pop();
+    static bool empty();
+    static std::size_t size();
+
+private:
+    static std::mutex m_;
+    static std::vector<SplitInfo> closedSplits_;
+};
+
+}  // namespace chatterino
+
+#endif  // CLOSEDSPLITS_HPP

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -19,9 +19,11 @@
 #include "widgets/dialogs/UserInfoPopup.hpp"
 #include "widgets/helper/ChannelView.hpp"
 #include "widgets/helper/DebugPopup.hpp"
+#include "widgets/helper/NotebookTab.hpp"
 #include "widgets/helper/ResizingTextEdit.hpp"
 #include "widgets/helper/SearchPopup.hpp"
 #include "widgets/helper/Shortcut.hpp"
+#include "widgets/splits/ClosedSplits.hpp"
 #include "widgets/splits/SplitContainer.hpp"
 #include "widgets/splits/SplitHeader.hpp"
 #include "widgets/splits/SplitInput.hpp"
@@ -415,6 +417,10 @@ void Split::deleteFromContainer()
 {
     if (this->container_) {
         this->container_->deleteSplit(this);
+        auto *tab = this->getContainer()->getTab();
+        tab->connect(tab, &QWidget::destroyed,
+                     [tab]() mutable { ClosedSplits::invalidateTab(tab); });
+        ClosedSplits::push({this->getChannel()->getName(), tab});
     }
 }
 


### PR DESCRIPTION
since ctrl+shift+t is already used to open a new tab, the hotkey is ctrl+g atm
when you close a split, you can reopen it with ctrl+g and it opens in the correct tab and also selects it into foreground
when you closed the tab, the split gets open on currently selected tab