### PR TITLE
Removed unused signal in TwitchChannel.

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -89,7 +89,6 @@ TwitchChannel::TwitchChannel(const QString &name,
 {
     log("[TwitchChannel:{}] Opened", name);
 
-    this->tabHighlightRequested.connect([](HighlightState state) {});
     this->liveStatusChanged.connect([this]() {
         if (this->isLive() == 1) {
         }

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -92,7 +92,6 @@ public:
     pajlada::Signals::NoArgSignal userStateChanged;
     pajlada::Signals::NoArgSignal liveStatusChanged;
     pajlada::Signals::NoArgSignal roomModesChanged;
-    pajlada::Signals::Signal<HighlightState> tabHighlightRequested;
 
 protected:
     void addRecentChatter(const MessagePtr &message) override;

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -552,11 +552,7 @@ void ChannelView::setChannel(ChannelPtr newChannel)
     this->queueUpdate();
 
     // Notifications
-    TwitchChannel *tc = dynamic_cast<TwitchChannel *>(newChannel.get());
-    if (tc != nullptr) {
-        tc->tabHighlightRequested.connect([this](HighlightState state) {
-            this->tabHighlightRequested.invoke(state);
-        });
+    if (auto tc = dynamic_cast<TwitchChannel *>(newChannel.get())) {
         tc->liveStatusChanged.connect([this]() {
             this->liveStatusChanged.invoke();  //
         });


### PR DESCRIPTION
After @pajlada added a Live status indicator, `tabHighlightRequested` signal in `TwitchChannel` became unused and can be safely removed.