### PR TITLE
Fix emote scale

### DIFF
--- a/src/messages/ImageSet.cpp
+++ b/src/messages/ImageSet.cpp
@@ -58,6 +58,10 @@ const ImagePtr &ImageSet::getImage3() const
 
 const ImagePtr &ImageSet::getImage(float scale) const
 {
+    auto emoteScale = getSettings()->emoteScale.getValue();
+
+    scale += emoteScale - 1.f;
+
     int quality = 1;
 
     if (scale > 2.999)

--- a/src/messages/ImageSet.cpp
+++ b/src/messages/ImageSet.cpp
@@ -58,9 +58,7 @@ const ImagePtr &ImageSet::getImage3() const
 
 const ImagePtr &ImageSet::getImage(float scale) const
 {
-    auto emoteScale = getSettings()->emoteScale.getValue();
-
-    scale += emoteScale - 1.f;
+    scale *= getSettings()->emoteScale;
 
     int quality = 1;
 

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -117,8 +117,11 @@ void EmoteElement::addToContainer(MessageLayoutContainer &container,
             auto image = this->emote_->images.getImage(container.getScale());
             if (image->isEmpty()) return;
 
-            auto size = QSize(int(container.getScale() * image->width()),
-                              int(container.getScale() * image->height()));
+            auto emoteScale = getSettings()->emoteScale.getValue();
+
+            auto size =
+                QSize(int(container.getScale() * image->width() * emoteScale),
+                      int(container.getScale() * image->height() * emoteScale));
 
             container.addElement((new ImageLayoutElement(*this, image, size))
                                      ->setLink(this->getLink()));


### PR DESCRIPTION
The emote scale slider now works again.
It also contributes to the image set calculations, which figures out which of the images we should load from the image set