### PR TITLE
save messages sent with ctrl enter to history as well

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -209,11 +209,6 @@ void SplitInput::installKeyPressedEvent()
             {
                 this->currMsg_ = QString();
                 this->ui_.textEdit->setText(QString());
-                this->prevIndex_ = 0;
-            }
-            else if (message == this->prevMsg_.at(this->prevMsg_.size() - 1))
-            {
-                this->prevMsg_.removeLast();
             }
             this->prevIndex_ = this->prevMsg_.size();
         }


### PR DESCRIPTION
Should stop messages sent with ctrl+enter from being left out of history(#810), from brief testing it seems to do just that.