### PR TITLE
fixed badges scaling with emote scale slider #817

### DIFF
--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -121,7 +121,10 @@ void EmoteElement::addToContainer(MessageLayoutContainer &container,
             if (image->isEmpty())
                 return;
 
-            auto emoteScale = getSettings()->emoteScale.getValue();
+            auto emoteScale =
+                this->getFlags().hasAny(MessageElementFlag::Badges)
+                    ? 1
+                    : getSettings()->emoteScale.getValue();
 
             auto size =
                 QSize(int(container.getScale() * image->width() * emoteScale),


### PR DESCRIPTION
Fixes #817.
Now doesnt scale badges at all, instead of scaling half of them.