### PR TITLE
[WIP] custom ffz moderator badges #819

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -263,7 +263,8 @@ SOURCES += \
     src/common/UsernameSet.cpp \
     src/widgets/settingspages/AdvancedPage.cpp \
     src/util/IncognitoBrowser.cpp \
-    src/widgets/splits/ClosedSplits.cpp
+    src/widgets/splits/ClosedSplits.cpp \
+    src/providers/ffz/FfzModBadge.cpp
 
 HEADERS  += \
     src/Application.hpp \
@@ -466,7 +467,8 @@ HEADERS  += \
     src/common/UsernameSet.hpp \
     src/widgets/settingspages/AdvancedPage.hpp \
     src/util/IncognitoBrowser.hpp \
-    src/widgets/splits/ClosedSplits.hpp
+    src/widgets/splits/ClosedSplits.hpp \
+    src/providers/ffz/FfzModBadge.hpp
 
 RESOURCES += \
     resources/resources.qrc \

--- a/src/providers/ffz/FfzModBadge.cpp
+++ b/src/providers/ffz/FfzModBadge.cpp
@@ -1,0 +1,86 @@
+#include "FfzModBadge.hpp"
+
+#include <QBuffer>
+#include <QImageReader>
+#include <QJsonObject>
+#include <QPainter>
+#include <QString>
+
+#include "common/NetworkRequest.hpp"
+#include "common/Outcome.hpp"
+#include "messages/Emote.hpp"
+
+namespace chatterino {
+
+FfzModBadge::FfzModBadge(const QString &channelName)
+    : channelName_(channelName)
+{
+}
+
+void FfzModBadge::loadCustomModBadge()
+{
+    static QString partialUrl("https://api.frankerfacez.com/v1/_room/");
+
+    QString url = partialUrl + channelName_;
+    NetworkRequest req(url);
+    req.setCaller(QThread::currentThread());
+    req.onSuccess([this](auto result) -> Outcome {
+        auto root = result.parseJson();
+
+        auto modBadgeUrlField =
+            root.value("room").toObject().value("moderator_badge");
+        if (modBadgeUrlField.isNull())
+            return Failure;
+
+        auto badgeUrl = "https:" + modBadgeUrlField.toString();
+        /* doesnt work for some reason
+        auto badgeOverlay =
+            Image::fromUrl({"https:" + modBadgeUrlField.toString()});
+        auto badgeOverlayPixmap = badgeOverlay->pixmap();
+        if (!badgeOverlayPixmap)
+            return Failure;
+        */
+        NetworkRequest getBadge(badgeUrl);
+        getBadge.setCaller(QThread::currentThread());
+        getBadge.onSuccess([this, &badgeUrl](auto result) -> Outcome {
+            auto data = result.getData();
+
+            QBuffer buffer(const_cast<QByteArray *>(&data));
+            buffer.open(QIODevice::ReadOnly);
+            QImageReader reader(&buffer);
+            if (reader.imageCount() == 0)
+                return Failure;
+            auto badgeOverlay = QPixmap::fromImageReader(&reader);
+
+            QPixmap badgePixmap(18, 18);
+            // the default mod badge green color
+            badgePixmap.fill(QColor("#34AE0A"));
+
+            QPainter painter(&badgePixmap);
+            QRectF rect(0, 0, 18, 18);
+            painter.drawPixmap(rect, badgeOverlay, rect);
+
+            auto emote = Emote{{""},
+                               ImageSet{Image::fromPixmap(badgePixmap)},
+                               Tooltip{"Twitch Channel Moderator"},
+                               Url{badgeUrl}};
+
+            this->badge_ = std::make_shared<Emote>(emote);
+
+            return Success;
+        });
+
+        getBadge.execute();
+
+        return Success;
+    });
+
+    req.execute();
+}
+
+EmotePtr FfzModBadge::badge() const
+{
+    return this->badge_;
+}
+
+}  // namespace chatterino

--- a/src/providers/ffz/FfzModBadge.hpp
+++ b/src/providers/ffz/FfzModBadge.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QString>
+#include <boost/optional.hpp>
+
+namespace chatterino {
+
+struct Emote;
+using EmotePtr = std::shared_ptr<const Emote>;
+
+class FfzModBadge
+{
+public:
+    FfzModBadge(const QString &channelName);
+
+    void loadCustomModBadge();
+
+    EmotePtr badge() const;
+
+private:
+    const QString channelName_;
+    EmotePtr badge_;
+};
+
+}  // namespace chatterino

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -90,6 +90,7 @@ TwitchChannel::TwitchChannel(const QString &name,
     , globalFfz_(ffz)
     , bttvEmotes_(std::make_shared<EmoteMap>())
     , ffzEmotes_(std::make_shared<EmoteMap>())
+    , ffzCustomModBadge_(name)
     , mod_(false)
 {
     log("[TwitchChannel:{}] Opened", name);
@@ -142,6 +143,7 @@ void TwitchChannel::initialize()
 {
     this->refreshChatters();
     this->refreshChannelEmotes();
+    this->ffzCustomModBadge_.loadCustomModBadge();
 }
 
 bool TwitchChannel::isEmpty() const
@@ -779,6 +781,14 @@ boost::optional<EmotePtr> TwitchChannel::twitchBadge(
             return it2->second;
         }
     }
+    return boost::none;
+}
+
+boost::optional<EmotePtr> TwitchChannel::ffzCustomModBadge() const
+{
+    if (auto badge = this->ffzCustomModBadge_.badge())
+        return badge;
+
     return boost::none;
 }
 

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -6,6 +6,7 @@
 #include "common/Outcome.hpp"
 #include "common/UniqueAccess.hpp"
 #include "common/UsernameSet.hpp"
+#include "providers/ffz/FfzModBadge.hpp"
 #include "providers/twitch/TwitchEmotes.hpp"
 
 #include <rapidjson/document.h>
@@ -84,6 +85,7 @@ public:
     void refreshChannelEmotes();
 
     // Badges
+    boost::optional<EmotePtr> ffzCustomModBadge() const;
     boost::optional<EmotePtr> twitchBadge(const QString &set,
                                           const QString &version) const;
 
@@ -141,6 +143,7 @@ private:
     UniqueAccess<std::map<QString, std::map<QString, EmotePtr>>>
         badgeSets_;  // "subscribers": { "0": ... "3": ... "6": ...
     UniqueAccess<std::vector<CheerEmoteSet>> cheerEmoteSets_;
+    FfzModBadge ffzCustomModBadge_;
 
     bool mod_ = false;
     UniqueAccess<QString> roomID_;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1091,7 +1091,14 @@ void TwitchMessageBuilder::appendTwitchBadges()
         }
         else if (badge == "moderator/1")
         {
-            // TODO: Implement custom FFZ moderator badge
+            if (auto customModBadge = this->twitchChannel->ffzCustomModBadge())
+            {
+                this->emplace<EmoteElement>(
+                        customModBadge.get(),
+                        MessageElementFlag::BadgeChannelAuthority)
+                    ->setTooltip((*customModBadge)->tooltip.string);
+                continue;
+            }
             this->emplace<ImageElement>(
                     Image::fromPixmap(app->resources->twitch.moderator),
                     MessageElementFlag::BadgeChannelAuthority)


### PR DESCRIPTION
Fixes #819.
It works, but the code is quite lidl.
Using Image::pixmap() always returns boost::none for some reason. 

![123](https://user-images.githubusercontent.com/28187538/47521302-1c906600-d8ac-11e8-8ba5-ac9fc16f69d3.png)
