### PR TITLE
fix ctrl not registering with numlock enter

### DIFF
--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -205,7 +205,7 @@ void SplitInput::installKeyPressedEvent()
             }
 
             event->accept();
-            if (!(event->modifiers() == Qt::ControlModifier))
+            if (!(event->modifiers() & Qt::ControlModifier))
             {
                 this->currMsg_ = QString();
                 this->ui_.textEdit->setText(QString());


### PR DESCRIPTION
checking it like this makes it worth with both ctrl+enter and ctrl+numlock enter, not entirely sure why it worked before with == at all

fixes #832 