### PR TITLE
Removed second unnecessary getLogviewerLogs() call.

### DIFF
--- a/src/widgets/dialogs/LogsPopup.cpp
+++ b/src/widgets/dialogs/LogsPopup.cpp
@@ -39,7 +39,6 @@ void LogsPopup::setInfo(ChannelPtr channel, QString userName)
     this->getRoomID();
     this->setWindowTitle(this->userName_ + "'s logs in #" +
                          this->channel_->getName());
-    this->getLogviewerLogs();
 }
 
 void LogsPopup::setMessages(std::vector<MessagePtr> &messages)


### PR DESCRIPTION
Second getLogviewerLogs() call causes the QMessageBox double open.
Call should only occur when the ID is successfully received.

![2018-10-26_22-12-52](https://user-images.githubusercontent.com/4051126/47587700-6b053980-d96c-11e8-8ef4-33aeb09cc521.gif)
