### PR TITLE
Added closing LogsPopup with QMessageBox.

### DIFF
--- a/src/widgets/dialogs/LogsPopup.cpp
+++ b/src/widgets/dialogs/LogsPopup.cpp
@@ -153,14 +153,22 @@ void LogsPopup::getOverrustleLogs()
 
     NetworkRequest req(url);
     req.setCaller(QThread::currentThread());
-    req.onError([channelName](int errorCode) {
-        //        this->close();
+    req.onError([this, channelName](int errorCode) {
         auto box = new QMessageBox(
             QMessageBox::Information, "Error getting logs",
             "No logs could be found for channel " + channelName);
         box->setAttribute(Qt::WA_DeleteOnClose);
         box->show();
         box->raise();
+
+        static QSet<int> closeButtons {
+            QMessageBox::Ok,
+            QMessageBox::Close,
+        };
+        if (closeButtons.contains(box->exec())) 
+        {
+            this->close();
+        }
 
         return true;
     });


### PR DESCRIPTION
This PR allows user to close LogsPopup window with one click on QMessageBox, as the logs can not be found and window becomes useless.

Of course this PR works only with this: https://github.com/fourtf/chatterino2/pull/835.
Because second QMessageBox will try to close already closed window and chatterino2 will just crash. 

![2018-10-26_22-39-10](https://user-images.githubusercontent.com/4051126/47588808-00ee9380-d970-11e8-9807-5fdfe29fc8e0.gif)