### PR TITLE
Refactored LogsPopup.

### DIFF
--- a/src/widgets/dialogs/LogsPopup.cpp
+++ b/src/widgets/dialogs/LogsPopup.cpp
@@ -50,8 +50,7 @@ void LogsPopup::setInfo(ChannelPtr channel, QString userName)
 
     this->getRoomID();
     this->setWindowTitle(this->userName_ + "'s logs in #" +
-                         this->channel_->getName());
-    this->getLogviewerLogs();
+                         this->channelName_);
 }
 
 void LogsPopup::setMessages(std::vector<MessagePtr> &messages)
@@ -64,17 +63,10 @@ void LogsPopup::setMessages(std::vector<MessagePtr> &messages)
 
 void LogsPopup::getRoomID()
 {
-    TwitchChannel *twitchChannel =
-        dynamic_cast<TwitchChannel *>(this->channel_.get());
-    if (twitchChannel == nullptr)
-    {
-        return;
-    }
-
     const auto onIdFetched = [=](const QString &userID) {
         this->getLogviewerLogs(userID);
     };
-    PartialTwitchUser::byName(twitchChannel->getName())
+    PartialTwitchUser::byName(this->channelName_)
         .getId(onIdFetched, this);
 }
 

--- a/src/widgets/dialogs/LogsPopup.cpp
+++ b/src/widgets/dialogs/LogsPopup.cpp
@@ -48,7 +48,12 @@ void LogsPopup::setInfo(ChannelPtr channel, QString userName)
         return;
     }  
 
-    this->getRoomID();
+    // Get channel ID.
+    PartialTwitchUser::byName(this->channelName_)
+        .getId([=](const QString &roomID) {
+            this->getLogviewerLogs(roomID); 
+        }, this);
+
     this->setWindowTitle(this->userName_ + "'s logs in #" +
                          this->channelName_);
 }
@@ -59,15 +64,6 @@ void LogsPopup::setMessages(std::vector<MessagePtr> &messages)
 
     logsChannel->addMessagesAtStart(messages);
     this->channelView_->setChannel(logsChannel);
-}
-
-void LogsPopup::getRoomID()
-{
-    const auto onIdFetched = [=](const QString &userID) {
-        this->getLogviewerLogs(userID);
-    };
-    PartialTwitchUser::byName(this->channelName_)
-        .getId(onIdFetched, this);
 }
 
 void LogsPopup::getLogviewerLogs(const QString &roomID)

--- a/src/widgets/dialogs/LogsPopup.cpp
+++ b/src/widgets/dialogs/LogsPopup.cpp
@@ -61,14 +61,13 @@ void LogsPopup::getRoomID()
     }
 
     const auto onIdFetched = [=](const QString &userID) {
-        this->roomID_ = userID.toInt();
-        this->getLogviewerLogs();
+        this->getLogviewerLogs(userID);
     };
     PartialTwitchUser::byName(twitchChannel->getName())
         .getId(onIdFetched, this);
 }
 
-void LogsPopup::getLogviewerLogs()
+void LogsPopup::getLogviewerLogs(const QString &roomID)
 {
     TwitchChannel *twitchChannel =
         dynamic_cast<TwitchChannel *>(this->channel_.get());
@@ -90,7 +89,7 @@ void LogsPopup::getLogviewerLogs()
         return true;
     });
 
-    req.onSuccess([this, channelName](auto result) -> Outcome {
+    req.onSuccess([this, roomID](auto result) -> Outcome {
         auto data = result.parseJson();
         std::vector<MessagePtr> messages;
 
@@ -105,7 +104,7 @@ void LogsPopup::getLogviewerLogs()
             message.insert(1, "historical=1;");
             message.insert(1, QString("tmi-sent-ts=%10000;")
                                   .arg(messageObject["time"].toInt()));
-            message.insert(1, QString("room-id=%1;").arg(this->roomID_));
+            message.insert(1, QString("room-id=%1;").arg(roomID));
 
             MessageParseArgs args;
             auto ircMessage =

--- a/src/widgets/dialogs/LogsPopup.hpp
+++ b/src/widgets/dialogs/LogsPopup.hpp
@@ -25,6 +25,7 @@ private:
     ChannelPtr channel_;
 
     QString userName_;
+    QString channelName_;
 
     void initLayout();
     void setMessages(std::vector<MessagePtr> &messages);

--- a/src/widgets/dialogs/LogsPopup.hpp
+++ b/src/widgets/dialogs/LogsPopup.hpp
@@ -29,7 +29,6 @@ private:
 
     void initLayout();
     void setMessages(std::vector<MessagePtr> &messages);
-    void getRoomID();
     void getOverrustleLogs();
     void getLogviewerLogs(const QString &roomID);
 };

--- a/src/widgets/dialogs/LogsPopup.hpp
+++ b/src/widgets/dialogs/LogsPopup.hpp
@@ -25,13 +25,12 @@ private:
     ChannelPtr channel_;
 
     QString userName_;
-    int roomID_;
 
     void initLayout();
     void setMessages(std::vector<MessagePtr> &messages);
     void getRoomID();
     void getOverrustleLogs();
-    void getLogviewerLogs();
+    void getLogviewerLogs(const QString &roomID);
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
1. Removed getting channel ID from third party service and placed getting ID with own implementation which Chatterino2 has already.
2. `roomID_` is only used in one place, so there is no need to have it in header, better to pass it as argument. Together with this removed useless casts `QString -> int -> QString` of `roomID`.
3. TwitchChannel dynamic cast is used in three places only to get `channelName`, I collapsed dynamic cast and placed it in one place.

There will probably be a conflict with my previous PR, because I separated fix, feature and refactor into several PR's. ¯\_(ツ)_/¯