### PR TITLE
Properly displays mentions in splitheader-tabs

### DIFF
--- a/src/widgets/helper/NotebookTab.cpp
+++ b/src/widgets/helper/NotebookTab.cpp
@@ -199,7 +199,8 @@ void NotebookTab::setLive(bool isLive)
 
 void NotebookTab::setHighlightState(HighlightState newHighlightStyle)
 {
-    if (this->isSelected() || !this->highlightEnabled_)
+    if (this->isSelected() || (!this->highlightEnabled_ &&
+                               newHighlightStyle == HighlightState::NewMessage))
     {
         return;
     }


### PR DESCRIPTION
 even if 'enable highlighting on new message' is disabled #800 