### PR TITLE
Fixed pause on mouse hover

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -697,9 +697,9 @@ MessageElementFlags ChannelView::getFlags() const
 
 bool ChannelView::isPaused()
 {
-    return false;
-    //    return this->pausedTemporarily_ || this->pausedBySelection_ ||
-    //    this->pausedByScrollingUp_;
+    // return false;
+    return this->pausedTemporarily_;
+    //   || this->pausedBySelection_ || this->pausedByScrollingUp_;
 }
 
 void ChannelView::updatePauseStatus()


### PR DESCRIPTION
Fixes the intended 1s pause when hovering over a message (if enabled in settings). fixes #527 