### PR TITLE
Fixed Unmaximize button in title bar for Windows.

### DIFF
--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -125,13 +125,13 @@ void BaseWindow::init()
                                      this->setWindowState(Qt::WindowMinimized |
                                                           this->windowState());
                                  });
-                QObject::connect(
-                    _maxButton, &TitleBarButton::leftClicked, this, [this] {
-                        this->setWindowState(this->windowState() ==
-                                                     Qt::WindowMaximized
-                                                 ? Qt::WindowActive
-                                                 : Qt::WindowMaximized);
-                    });
+                QObject::connect(_maxButton, &TitleBarButton::leftClicked, this, 
+                                 [this, _maxButton] {
+                    this->setWindowState(_maxButton->getButtonStyle() !=
+                                                TitleBarButtonStyle::Maximize
+                                                    ? Qt::WindowActive
+                                                    : Qt::WindowMaximized);
+                });
                 QObject::connect(_exitButton, &TitleBarButton::leftClicked, this,
                                  [this] { this->close(); });
 

--- a/src/widgets/BaseWindow.cpp
+++ b/src/widgets/BaseWindow.cpp
@@ -125,13 +125,14 @@ void BaseWindow::init()
                                      this->setWindowState(Qt::WindowMinimized |
                                                           this->windowState());
                                  });
-                QObject::connect(_maxButton, &TitleBarButton::leftClicked, this, 
+                QObject::connect(_maxButton, &TitleBarButton::leftClicked, this,
                                  [this, _maxButton] {
-                    this->setWindowState(_maxButton->getButtonStyle() !=
-                                                TitleBarButtonStyle::Maximize
-                                                    ? Qt::WindowActive
-                                                    : Qt::WindowMaximized);
-                });
+                                     this->setWindowState(
+                                         _maxButton->getButtonStyle() !=
+                                                 TitleBarButtonStyle::Maximize
+                                             ? Qt::WindowActive
+                                             : Qt::WindowMaximized);
+                                 });
                 QObject::connect(_exitButton, &TitleBarButton::leftClicked, this,
                                  [this] { this->close(); });
 


### PR DESCRIPTION
There's a pretty unobvious bug here. Windows only.
If user maximize window by drag and drop to top of screen, 'Unmaximize' button starts working only after second click.
The easiest way I've found to fix this bug is to simply change the condition from `this->windowState()` to `_maxButton->getButtonStyle()`.

![2018-10-28_12-05-41](https://user-images.githubusercontent.com/4051126/47614144-0224db00-daac-11e8-96a3-b137fd1554cc.gif)
