### PR TITLE
save settings after clicking ok

### DIFF
--- a/src/widgets/dialogs/SettingsDialog.cpp
+++ b/src/widgets/dialogs/SettingsDialog.cpp
@@ -216,6 +216,7 @@ void SettingsDialog::themeChangedEvent()
 ///// Widget creation helpers
 void SettingsDialog::onOkClicked()
 {
+    pajlada::Settings::SettingManager::gSave();
     this->close();
 }
 


### PR DESCRIPTION
from what I can tell this is what saves all the preferences correctly, seems to work after clicking Ok and closing client abruptly (kill, turn off computer etc)