### PR TITLE
Moved turbo badge to vanity

### DIFF
--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1123,19 +1123,19 @@ void TwitchMessageBuilder::appendTwitchBadges()
                     MessageElementFlag::BadgeChannelAuthority)
                 ->setTooltip("Twitch Channel Moderator");
         }
-        else if (badge == "turbo/1")
-        {
-            this->emplace<ImageElement>(
-                    Image::fromPixmap(app->resources->twitch.turbo),
-                    MessageElementFlag::BadgeGlobalAuthority)
-                ->setTooltip("Twitch Turbo Subscriber");
-        }
         else if (badge == "broadcaster/1")
         {
             this->emplace<ImageElement>(
                     Image::fromPixmap(app->resources->twitch.broadcaster),
                     MessageElementFlag::BadgeChannelAuthority)
                 ->setTooltip("Twitch Broadcaster");
+        }
+        else if (badge == "turbo/1")
+        {
+            this->emplace<ImageElement>(
+                    Image::fromPixmap(app->resources->twitch.turbo),
+                    MessageElementFlag::BadgeVanity)
+                ->setTooltip("Twitch Turbo Subscriber");
         }
         else if (badge == "premium/1")
         {

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -230,7 +230,7 @@ void GeneralPage::initLayout(SettingsLayout &layout)
                        s.emojiSet);
 
     layout.addTitle("Badges");
-    layout.addCheckbox("Show authority badges (staff, admin, turbo, etc)",
+    layout.addCheckbox("Show authority badges (staff, admin)",
                        getSettings()->showBadgesGlobalAuthority);
     layout.addCheckbox("Show channel badges (broadcaster, moderator)",
                        getSettings()->showBadgesChannelAuthority);


### PR DESCRIPTION
Turbo badge was in the global authority enum, moved to vanity