### PR TITLE
Fixes unpause caused by left clicking

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -117,9 +117,11 @@ ChannelView::ChannelView(BaseWidget *parent)
 
     this->pauseTimer_.setSingleShot(true);
     QObject::connect(&this->pauseTimer_, &QTimer::timeout, this, [this] {
-        /// remove elements that are finite
+        /// remove expired elements
         for (auto it = this->pauses_.begin(); it != this->pauses_.end();)
-            it = it->second ? this->pauses_.erase(it) : ++it;
+            it = (it->second && it->second <= this->pauseEnd_)
+                     ? this->pauses_.erase(it)
+                     : ++it;
 
         this->updatePauseTimer();
     });


### PR DESCRIPTION
left-clicking with linksDoubleClickOnly and pauseChatOnHover enabled
while hovering on chat caused a short unpause making it hard to select text correctly