### PR TITLE
add back settings for hiding buttons

### DIFF
--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -190,6 +190,8 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Show input when empty", s.showEmptyInput);
     layout.addCheckbox("Show input message length", s.showMessageLength);
+    layout.addCheckbox("Hide preferences button (ctrl+p to show)", s.hidePreferencesButton);
+    layout.addCheckbox("Hide user button", s.hideUserButton);
 
     layout.addTitle("Messages");
     layout.addCheckbox("Timestamps", s.showTimestamps);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -190,7 +190,8 @@ void GeneralPage::initLayout(SettingsLayout &layout)
     layout.addCheckbox("Show tab close button", s.showTabCloseButton);
     layout.addCheckbox("Show input when empty", s.showEmptyInput);
     layout.addCheckbox("Show input message length", s.showMessageLength);
-    layout.addCheckbox("Hide preferences button (ctrl+p to show)", s.hidePreferencesButton);
+    layout.addCheckbox("Hide preferences button (ctrl+p to show)", 
+                       s.hidePreferencesButton);
     layout.addCheckbox("Hide user button", s.hideUserButton);
 
     layout.addTitle("Messages");


### PR DESCRIPTION
The settings page got changed at some point but these fully functional settings were never added back, this merely adds checkboxes for those existing settings back.

will close #907 