### PR TITLE
add account switcher popup flag for linux

### DIFF
--- a/src/widgets/AccountSwitchPopupWidget.cpp
+++ b/src/widgets/AccountSwitchPopupWidget.cpp
@@ -14,6 +14,9 @@ AccountSwitchPopupWidget::AccountSwitchPopupWidget(QWidget *parent)
     : QWidget(parent)
 {
     this->setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+#ifdef Q_OS_LINUX
+    this->setWindowFlag(Qt::Popup);
+#endif
 
     this->setContentsMargins(0, 0, 0, 0);
 


### PR DESCRIPTION
needed for some tiling wms to stop tiling this popup window, similar to the UserInfoPopup, which does work fine.