### PR TITLE
disable requests to resolve link info when its disabled

### DIFF
--- a/src/providers/LinkResolver.cpp
+++ b/src/providers/LinkResolver.cpp
@@ -12,9 +12,12 @@ namespace chatterino {
 void LinkResolver::getLinkInfo(
     const QString url, std::function<void(QString, Link)> successCallback)
 {
+    if (!getSettings()->linkInfoTooltip) {
+        successCallback("No link info loaded", Link(Link::Url, url));
+        return;
+    }
     QString requestUrl("https://braize.pajlada.com/chatterino/link_resolver/" +
                        QUrl::toPercentEncoding(url, "", "/:"));
-
     // Uncomment to test crashes
     // QTimer::singleShot(3000, [=]() {
     NetworkRequest request(requestUrl);


### PR DESCRIPTION
Don't make any requests to get link info while the setting isn't enabled, resolves #988