### PR TITLE
Mod action channel replacement

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1667,7 +1667,7 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserAction:
         {
             QString value = link.value;
-            value.replace("{user}", layout->getMessage()->loginName);
+            value.replace("{user}", layout->getMessage()->loginName).replace("{channel}", this->channel_->getName());
             this->channel_->sendMessage(value);
         }
         break;

--- a/src/widgets/settingspages/ModerationPage.cpp
+++ b/src/widgets/settingspages/ModerationPage.cpp
@@ -161,7 +161,7 @@ ModerationPage::ModerationPage()
         // clang-format off
         auto label = modMode.emplace<QLabel>(
             "Moderation mode is enabled by clicking <img width='18' height='18' src=':/buttons/modModeDisabled.png'> in a channel that you moderate.<br><br>"
-            "Moderation buttons can be bound to chat commands such as \"/ban {user}\", \"/timeout {user} 1000\" or any other custom text commands.<br>");
+            "Moderation buttons can be bound to chat commands such as \"/ban {user}\", \"/timeout {user} 1000\", \"/w someusername !report {user} was bad in channel {channel}\" or any other custom text commands.<br>");
         label->setWordWrap(true);
         label->setStyleSheet("color: #bbb");
         // clang-format on


### PR DESCRIPTION
Allows users to use `{channel}` in moderation actions

Also this might be a good opportunity to add `{uuid}` maybe so you can make a /delete moderation action?