### PR TITLE
stop emotes from being cut off (pajlada-dev)

### DIFF
--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -165,7 +165,8 @@ void MessageLayoutContainer::breakLine()
         //        {
         if (element->getRect().height() < this->textLineHeight_)
         {
-            //yExtra -= (this->textLineHeight_ - element->getRect().height()) / 2;
+            // yExtra -= (this->textLineHeight_ - element->getRect().height()) /
+            // 2;
         }
 
         element->setPosition(

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -165,7 +165,7 @@ void MessageLayoutContainer::breakLine()
         //        {
         if (element->getRect().height() < this->textLineHeight_)
         {
-            yExtra -= (this->textLineHeight_ - element->getRect().height()) / 2;
+            //yExtra -= (this->textLineHeight_ - element->getRect().height()) / 2;
         }
 
         element->setPosition(

--- a/src/messages/layouts/MessageLayoutContainer.cpp
+++ b/src/messages/layouts/MessageLayoutContainer.cpp
@@ -157,7 +157,7 @@ void MessageLayoutContainer::breakLine()
         int yExtra = 0;
         if (isCompactEmote)
         {
-            // yExtra = (COMPACT_EMOTES_OFFSET / 2) * this->scale_;
+            yExtra = (COMPACT_EMOTES_OFFSET / 2) * this->scale_;
         }
 
         //        if (element->getCreator().getFlags() &
@@ -165,8 +165,7 @@ void MessageLayoutContainer::breakLine()
         //        {
         if (element->getRect().height() < this->textLineHeight_)
         {
-            // yExtra -= (this->textLineHeight_ - element->getRect().height()) /
-            // 2;
+            yExtra -= (this->textLineHeight_ - element->getRect().height()) / 2;
         }
 
         element->setPosition(


### PR DESCRIPTION
See #906 

I had this patch enabled for a few months now and really the only thing it breaks is the reconnected/etc messages. I think those messages being misaligned is preferable to every emote being cut off, personally.

This is the same as #906 but as requested by @Ckath into `pajlada-dev` for testing/development purposes.