### PR TITLE
Opening streams from toast + quickfix highlights in light theme

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -144,7 +144,7 @@ public:
         "/highlighting/whisperHighlight/enableSound", false};
     BoolSetting enableWhisperHighlightTaskbar = {
         "/highlighting/whisperHighlight/enableTaskbarFlashing", false};
-    QStringSetting highlightColor = {"/highlighting/color", "#4B282C"};
+    QStringSetting highlightColor = {"/highlighting/color", ""};
 
     BoolSetting longAlerts = {"/highlighting/alerts", false};
 

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -172,6 +172,7 @@ public:
                                             "qrc:/sounds/ping3.wav"};
 
     BoolSetting notificationToast = {"/notifications/enableToast", false};
+    QStringSetting openFromToast = {"/notifications/openFromToast", "in browser"};
 
     /// External tools
     // Streamlink

--- a/src/singletons/Theme.cpp
+++ b/src/singletons/Theme.cpp
@@ -38,6 +38,10 @@ void Theme::actuallyUpdate(double hue, double multiplier)
 
         this->splits.resizeHandle = QColor(0, 148, 255, 0xff);
         this->splits.resizeHandleBackground = QColor(0, 148, 255, 0x50);
+
+        // Highlighted Messages: theme support quick-fix
+        this->messages.backgrounds.highlighted =
+            QColor("#BD8489");
     }
     else
     {
@@ -46,6 +50,11 @@ void Theme::actuallyUpdate(double hue, double multiplier)
 
         this->splits.resizeHandle = QColor(0, 148, 255, 0x70);
         this->splits.resizeHandleBackground = QColor(0, 148, 255, 0x20);
+
+        // Highlighted Messages: theme support quick-fix
+        this->messages.backgrounds.highlighted =
+            QColor("#4B282C");
+
     }
 
     this->splits.header.background = getColor(0, sat, flat ? 1 : 0.9);
@@ -74,8 +83,13 @@ void Theme::actuallyUpdate(double hue, double multiplier)
     this->splits.dropPreviewBorder = QColor(0, 148, 255, 0xff);
 
     // Highlighted Messages
-    this->messages.backgrounds.highlighted =
-        QColor(getSettings()->highlightColor);
+    // hidden setting from PR #744 - if set it will overwrite theme color (for now!)
+    //TODO: implement full theme support
+    if (getSettings()->highlightColor != "") {
+        this->messages.backgrounds.highlighted =
+            QColor(getSettings()->highlightColor);
+    }
+
 }
 
 void Theme::normalizeColor(QColor &color)

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -17,6 +17,10 @@
 #include <QTableView>
 #include <QTimer>
 
+
+#define TOAST_REACTIONS \
+"in browser", "player in browser", "in streamlink", "don't open"
+
 namespace chatterino {
 
 NotificationPage::NotificationPage()
@@ -39,6 +43,18 @@ NotificationPage::NotificationPage()
                 settings.append(
                     this->createCheckBox("Enable toasts (Windows 8 or later)",
                                          getSettings()->notificationToast));
+                auto openIn =
+                    settings.emplace<QHBoxLayout>().withoutMargin();
+                {
+                openIn.emplace<QLabel>("Open stream from Toast:  ")->setSizePolicy(
+                                                    QSizePolicy::Maximum, QSizePolicy::Preferred);
+                openIn.append(
+                            this->createComboBox({TOAST_REACTIONS},
+                                                 getSettings()->openFromToast))->setSizePolicy(
+                            QSizePolicy::Maximum, QSizePolicy::Preferred);
+                }
+                openIn->setContentsMargins(40,0,0,0);
+                openIn->setSizeConstraint(QLayout::SetMaximumSize);
 #endif
                 auto customSound =
                     layout.emplace<QHBoxLayout>().withoutMargin();


### PR DESCRIPTION
I kinda messed up with my committing so I guess this is two changes in one .....

First change:
Implements #710

Added options for opening streams from clicking the toas notficiation: (according to options in splits)
- open in browser
- open player in browser
- open in streamlink (needs to be tested, but should in theory work, since I only use the already existing function)
- don't open the stream (in case someone wants to prevent opening streams "by accident")

![new setting](https://user-images.githubusercontent.com/16636423/56488125-bf354480-64dd-11e9-9d4a-37e718f7bd2d.png)

![Toast with text based on setting](https://user-images.githubusercontent.com/16636423/56488216-0c191b00-64de-11e9-8137-8095d93cf31e.png)

Second change:
Quick fix for #939 

Hidden setting introduced in PR #744 was setting a "default" highlight color. 
I changed it so the defaults depends on the basic hue of the theme. The hidding setting will only overwrite if it is populated in settings.json.

As mentioned in #703 a proper theme support for this should be implemented at one point.

