### PR TITLE
Replaced suffix character 0x206D with 0x2800 (fixes spamming)

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -123,7 +123,10 @@ TwitchChannel::TwitchChannel(const QString &name,
 
     // --
     this->messageSuffix_.append(' ');
-    this->messageSuffix_.append(QChar(0x206D));
+    // twitch "fixed" spamming with spaces like 0x206D in april 2019 
+    // this->messageSuffix_.append(QChar(0x206D));
+    // Braile Pattern Blank (0x2800) still works!
+    this->messageSuffix_.append(QChar(0x2800));
 
     // debugging
 #if 0


### PR DESCRIPTION
Adding Braille Blank Patter (0x2800) as suffix still allows spamming in twitch. Most other "blank" characters I tried do not work anymore.
Only negative point I can think of is that this character has width. But it is the only working one I can find.