### PR TITLE
Change to new character to make duplicate message error bypass work again

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -123,7 +123,7 @@ TwitchChannel::TwitchChannel(const QString &name,
 
     // --
     this->messageSuffix_.append(' ');
-    this->messageSuffix_.append(QChar(0x206D));
+    this->messageSuffix_.append("󠀀"); // E0000
 
     // debugging
 #if 0


### PR DESCRIPTION
Related to https://github.com/fourtf/chatterino2/pull/1019 . This character (\uE0000) appears to be not visible to users that had \u2800 visible.