### PR TITLE
Changed spamcharacter to a better one

### DIFF
--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -123,7 +123,7 @@ TwitchChannel::TwitchChannel(const QString &name,
 
     // --
     this->messageSuffix_.append(' ');
-    this->messageSuffix_.append("󠀀"); // E0000
+    this->messageSuffix_.append(QChar(0x034f));
 
     // debugging
 #if 0


### PR DESCRIPTION
The old character was a UTF-32 one which QChar doesn't properly support
(from testing it only seems to work with a single UTF-16 char and the one @TETYYS used before required 2)
If some font could see this char we should maybe change it, but from testing it seems to be a good 0-width char
close #1024 
