### PR TITLE
Fixed display of text message in empty tabs for Retina screen.

### DIFF
--- a/src/widgets/splits/SplitContainer.cpp
+++ b/src/widgets/splits/SplitContainer.cpp
@@ -3,6 +3,7 @@
 #include "Application.hpp"
 #include "common/Common.hpp"
 #include "debug/AssertInGuiThread.hpp"
+#include "singletons/Fonts.hpp"
 #include "singletons/Theme.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
@@ -526,6 +527,10 @@ void SplitContainer::paintEvent(QPaintEvent *)
         painter.fillRect(rect(), this->theme->splits.background);
 
         painter.setPen(this->theme->splits.header.text);
+
+        const auto font =
+            getApp()->fonts->getFont(FontStyle::ChatMedium, this->scale());
+        painter.setFont(font);
 
         QString text = "Click to add a split";
 


### PR DESCRIPTION
Lets respect Retina screens a little more.
This PR sets `ChatMedium` font for drawing text in empty tabs.

Before/After for Mac.
![mac](https://user-images.githubusercontent.com/4051126/56848110-81755900-68ed-11e9-98fe-648c19f5f3e6.png)

Before/After for Win.
![win](https://user-images.githubusercontent.com/4051126/56848155-14ae8e80-68ee-11e9-81eb-7a72426f271f.png)

