### PR TITLE
Refactored "open from toasts"-implementation

### DIFF
--- a/chatterino.pro
+++ b/chatterino.pro
@@ -339,7 +339,6 @@ HEADERS += \
     src/widgets/AccountSwitchPopupWidget.hpp \
     src/widgets/AccountSwitchWidget.hpp \
     src/widgets/AttachedWindow.hpp \
-    src/widgets/CommonTexts.hpp \
     src/widgets/dialogs/EmotePopup.hpp \
     src/widgets/dialogs/LastRunCrashDialog.hpp \
     src/widgets/dialogs/LoginDialog.hpp \

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -354,6 +354,7 @@ HEADERS += \
     src/widgets/dialogs/WelcomeDialog.hpp \
     src/widgets/helper/ChannelView.hpp \
     src/widgets/helper/ComboBoxItemDelegate.hpp \
+    src/widgets/helper/CommonTexts.hpp \
     src/widgets/helper/DebugPopup.hpp \
     src/widgets/helper/EditableModelView.hpp \
     src/widgets/helper/Line.hpp \

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -339,6 +339,7 @@ HEADERS += \
     src/widgets/AccountSwitchPopupWidget.hpp \
     src/widgets/AccountSwitchWidget.hpp \
     src/widgets/AttachedWindow.hpp \
+    src/widgets/CommonTexts.hpp \
     src/widgets/dialogs/EmotePopup.hpp \
     src/widgets/dialogs/LastRunCrashDialog.hpp \
     src/widgets/dialogs/LoginDialog.hpp \

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -4,7 +4,7 @@
 
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "controllers/moderationactions/ModerationAction.hpp"
-#include "widgets/helper/CommonTexts.hpp"
+#include "singletons/Toasts.hpp"
 
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/settings/settinglistener.hpp>
@@ -173,8 +173,9 @@ public:
                                             "qrc:/sounds/ping3.wav"};
 
     BoolSetting notificationToast = {"/notifications/enableToast", false};
-    QStringSetting openFromToast = {"/notifications/openFromToast",
-                                    OPEN_IN_BROWSER};
+    QStringSetting openFromToast = {
+        "/notifications/openFromToast",
+        Toasts::findStringFromReaction(ToastReactions::openInBrowser)};
 
     /// External tools
     // Streamlink

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -173,9 +173,9 @@ public:
                                             "qrc:/sounds/ping3.wav"};
 
     BoolSetting notificationToast = {"/notifications/enableToast", false};
-    QStringSetting openFromToast = {
+    IntSetting openFromToast = {
         "/notifications/openFromToast",
-        Toasts::findStringFromReaction(ToastReactions::openInBrowser)};
+        static_cast<int>(ToastReactions::OpenInBrowser)};
 
     /// External tools
     // Streamlink

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -175,7 +175,7 @@ public:
     BoolSetting notificationToast = {"/notifications/enableToast", false};
     IntSetting openFromToast = {
         "/notifications/openFromToast",
-        static_cast<int>(ToastReactions::OpenInBrowser)};
+        static_cast<int>(ToastReaction::OpenInBrowser)};
 
     /// External tools
     // Streamlink

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -4,6 +4,7 @@
 
 #include "controllers/highlights/HighlightPhrase.hpp"
 #include "controllers/moderationactions/ModerationAction.hpp"
+#include "widgets/helper/CommonTexts.hpp"
 
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/settings/settinglistener.hpp>
@@ -172,7 +173,8 @@ public:
                                             "qrc:/sounds/ping3.wav"};
 
     BoolSetting notificationToast = {"/notifications/enableToast", false};
-    QStringSetting openFromToast = {"/notifications/openFromToast", "in browser"};
+    QStringSetting openFromToast = {"/notifications/openFromToast",
+                                    OPEN_IN_BROWSER};
 
     /// External tools
     // Streamlink

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -9,6 +9,7 @@
 #include "providers/twitch/TwitchServer.hpp"
 #include "singletons/Paths.hpp"
 #include "util/StreamLink.hpp"
+#include "widgets/helper/CommonTexts.hpp"
 
 #ifdef Q_OS_WIN
 
@@ -88,7 +89,7 @@ public:
     {
         QString openingMode = getSettings()->openFromToast;
         QString link;
-        if (openingMode == "in browser")
+        if (openingMode == OPEN_IN_BROWSER)
         {
             if (platform_ == Platform::Twitch)
             {
@@ -96,7 +97,7 @@ public:
             }
             QDesktopServices::openUrl(QUrl(link));
         }
-        else if (openingMode == "player in browser")
+        else if (openingMode == OPEN_PLAYER_IN_BROWSER)
         {
             if (platform_ == Platform::Twitch)
             {
@@ -104,12 +105,12 @@ public:
             }
             QDesktopServices::openUrl(QUrl(link));
         }
-        else if (openingMode == "in streamlink")
+        else if (openingMode == OPEN_IN_STREAMLINK)
         {
-           openStreamlinkForChannel(channelName_);
+            openStreamlinkForChannel(channelName_);
         }
-        //the fourth and last option is "don't open"
-        //in this case obviously nothing should happen
+        // the fourth and last option is "don't open"
+        // in this case obviously nothing should happen
     }
 
     void toastActivated(int actionIndex) const
@@ -135,10 +136,12 @@ void Toasts::sendWindowsNotification(const QString &channelName, Platform p)
 
     templ.setTextField(widestr, WinToastLib::WinToastTemplate::FirstLine);
 
-    if (getSettings()->openFromToast != "don't open") {
-        QString mode = getSettings()->openFromToast ;
+    if (getSettings()->openFromToast != DONT_OPEN)
+    {
+        QString mode = getSettings()->openFromToast;
+        mode = mode.toLower();
 
-        templ.setTextField(L"Click here to open " + mode.toStdWString(),
+        templ.setTextField(L"Click here to " + mode.toStdWString(),
                            WinToastLib::WinToastTemplate::SecondLine);
     }
 

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -27,11 +27,11 @@
 
 namespace chatterino {
 
-std::map<ToastReactions, QString> Toasts::reactionToString = {
-    {ToastReactions::OpenInBrowser, OPEN_IN_BROWSER},
-    {ToastReactions::OpenInPlayer, OPEN_PLAYER_IN_BROWSER},
-    {ToastReactions::OpenInStreamlink, OPEN_IN_STREAMLINK},
-    {ToastReactions::DontOpen, DONT_OPEN}};
+std::map<ToastReaction, QString> Toasts::reactionToString = {
+    {ToastReaction::OpenInBrowser, OPEN_IN_BROWSER},
+    {ToastReaction::OpenInPlayer, OPEN_PLAYER_IN_BROWSER},
+    {ToastReaction::OpenInStreamlink, OPEN_IN_STREAMLINK},
+    {ToastReaction::DontOpen, DONT_OPEN}};
 
 bool Toasts::isEnabled()
 {
@@ -42,7 +42,7 @@ bool Toasts::isEnabled()
     return false;
 }
 
-QString Toasts::findStringFromReaction(const ToastReactions &reaction)
+QString Toasts::findStringFromReaction(const ToastReaction &reaction)
 {
     auto iterator = Toasts::reactionToString.find(reaction);
     if (iterator != Toasts::reactionToString.end())
@@ -59,7 +59,7 @@ QString Toasts::findStringFromReaction(
     const pajlada::Settings::Setting<int> &value)
 {
     int i = static_cast<int>(value);
-    return Toasts::findStringFromReaction(static_cast<ToastReactions>(i));
+    return Toasts::findStringFromReaction(static_cast<ToastReaction>(i));
 }
 
 void Toasts::sendChannelNotification(const QString &channelName, Platform p)
@@ -114,24 +114,24 @@ public:
     void toastActivated() const
     {
         QString link;
-        switch (static_cast<ToastReactions>(
+        switch (static_cast<ToastReaction>(
             getSettings()->openFromToast.getValue()))
         {
-            case ToastReactions::OpenInBrowser:
+            case ToastReaction::OpenInBrowser:
                 if (platform_ == Platform::Twitch)
                 {
                     link = "http://www.twitch.tv/" + channelName_;
                 }
                 QDesktopServices::openUrl(QUrl(link));
                 break;
-            case ToastReactions::OpenInPlayer:
+            case ToastReaction::OpenInPlayer:
                 if (platform_ == Platform::Twitch)
                 {
                     link = "https://player.twitch.tv/?channel=" + channelName_;
                 }
                 QDesktopServices::openUrl(QUrl(link));
                 break;
-            case ToastReactions::OpenInStreamlink:
+            case ToastReaction::OpenInStreamlink:
             {
                 openStreamlinkForChannel(channelName_);
                 break;
@@ -163,8 +163,8 @@ void Toasts::sendWindowsNotification(const QString &channelName, Platform p)
     std::wstring widestr = std::wstring(utf8_text.begin(), utf8_text.end());
 
     templ.setTextField(widestr, WinToastLib::WinToastTemplate::FirstLine);
-    if (static_cast<ToastReactions>(getSettings()->openFromToast.getValue()) !=
-        ToastReactions::DontOpen)
+    if (static_cast<ToastReaction>(getSettings()->openFromToast.getValue()) !=
+        ToastReaction::DontOpen)
     {
         QString mode =
             Toasts::findStringFromReaction(getSettings()->openFromToast);

--- a/src/singletons/Toasts.cpp
+++ b/src/singletons/Toasts.cpp
@@ -33,12 +33,6 @@ std::map<ToastReactions, QString> Toasts::reactionToString = {
     {ToastReactions::OpenInStreamlink, OPEN_IN_STREAMLINK},
     {ToastReactions::DontOpen, DONT_OPEN}};
 
-std::map<QString, ToastReactions> Toasts::stringToReaction = {
-    {OPEN_IN_BROWSER, ToastReactions::OpenInBrowser},
-    {OPEN_PLAYER_IN_BROWSER, ToastReactions::OpenInPlayer},
-    {OPEN_IN_STREAMLINK, ToastReactions::OpenInStreamlink},
-    {DONT_OPEN, ToastReactions::DontOpen}};
-
 bool Toasts::isEnabled()
 {
 #ifdef Q_OS_WIN
@@ -68,18 +62,6 @@ QString Toasts::findStringFromReaction(
     return Toasts::findStringFromReaction(static_cast<ToastReactions>(i));
 }
 
-ToastReactions Toasts::findReactionFromString(const QString &string)
-{
-    auto iterator = Toasts::stringToReaction.find(string);
-    if (iterator != Toasts::stringToReaction.end())
-    {
-        return iterator->second;
-    }
-    else
-    {
-        return ToastReactions::DontOpen;
-    }
-}
 void Toasts::sendChannelNotification(const QString &channelName, Platform p)
 {
 #ifdef Q_OS_WIN

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -21,9 +21,7 @@ public:
     static QString findStringFromReaction(const ToastReactions &reaction);
     static QString findStringFromReaction(
         const pajlada::Settings::Setting<int> &reaction);
-    static ToastReactions findReactionFromString(const QString &string);
     static std::map<ToastReactions, QString> reactionToString;
-    static std::map<QString, ToastReactions> stringToReaction;
 
     static bool isEnabled();
 

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -7,10 +7,21 @@ namespace chatterino {
 
 enum class Platform : uint8_t;
 
+enum class ToastReactions {
+    openInBrowser,
+    openInPlayer,
+    openInStreamlink,
+    dontOpen
+};
+
 class Toasts final : public Singleton
 {
 public:
     void sendChannelNotification(const QString &channelName, Platform p);
+    static QString findStringFromReaction(const ToastReactions &reaction);
+    static ToastReactions findReactionFromString(const QString &string);
+    static std::map<ToastReactions, QString> reactionToString;
+    static std::map<QString, ToastReactions> stringToReaction;
 
     static bool isEnabled();
 
@@ -18,6 +29,7 @@ private:
 #ifdef Q_OS_WIN
     void sendWindowsNotification(const QString &channelName, Platform p);
 #endif
+
     static void fetchChannelAvatar(
         const QString channelName,
         std::function<void(QString)> successCallback);

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -7,7 +7,7 @@ namespace chatterino {
 
 enum class Platform : uint8_t;
 
-enum class ToastReactions {
+enum class ToastReaction {
     OpenInBrowser = 0,
     OpenInPlayer = 1,
     OpenInStreamlink = 2,
@@ -18,10 +18,10 @@ class Toasts final : public Singleton
 {
 public:
     void sendChannelNotification(const QString &channelName, Platform p);
-    static QString findStringFromReaction(const ToastReactions &reaction);
+    static QString findStringFromReaction(const ToastReaction &reaction);
     static QString findStringFromReaction(
         const pajlada::Settings::Setting<int> &reaction);
-    static std::map<ToastReactions, QString> reactionToString;
+    static std::map<ToastReaction, QString> reactionToString;
 
     static bool isEnabled();
 

--- a/src/singletons/Toasts.hpp
+++ b/src/singletons/Toasts.hpp
@@ -8,10 +8,10 @@ namespace chatterino {
 enum class Platform : uint8_t;
 
 enum class ToastReactions {
-    openInBrowser,
-    openInPlayer,
-    openInStreamlink,
-    dontOpen
+    OpenInBrowser = 0,
+    OpenInPlayer = 1,
+    OpenInStreamlink = 2,
+    DontOpen = 3
 };
 
 class Toasts final : public Singleton
@@ -19,6 +19,8 @@ class Toasts final : public Singleton
 public:
     void sendChannelNotification(const QString &channelName, Platform p);
     static QString findStringFromReaction(const ToastReactions &reaction);
+    static QString findStringFromReaction(
+        const pajlada::Settings::Setting<int> &reaction);
     static ToastReactions findReactionFromString(const QString &string);
     static std::map<ToastReactions, QString> reactionToString;
     static std::map<QString, ToastReactions> stringToReaction;

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -1,0 +1,10 @@
+#ifndef COMMONTEXTS_HPP
+#define COMMONTEXTS_HPP
+
+#define OPEN_IN_BROWSER "Open in browser"
+#define OPEN_PLAYER_IN_BROWSER "Open in player in browser"
+#define OPEN_IN_STREAMLINK "Open in streamlink"
+#define DONT_OPEN "Don't open"
+
+
+#endif  // COMMONTEXTS_HPP

--- a/src/widgets/helper/CommonTexts.hpp
+++ b/src/widgets/helper/CommonTexts.hpp
@@ -1,10 +1,6 @@
-#ifndef COMMONTEXTS_HPP
-#define COMMONTEXTS_HPP
+#pragma once
 
 #define OPEN_IN_BROWSER "Open in browser"
 #define OPEN_PLAYER_IN_BROWSER "Open in player in browser"
 #define OPEN_IN_STREAMLINK "Open in streamlink"
 #define DONT_OPEN "Don't open"
-
-
-#endif  // COMMONTEXTS_HPP

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -139,10 +139,10 @@ QComboBox *NotificationPage::createToastReactionComboBox(
 {
     QComboBox *toastReactionOptions = new QComboBox();
 
-    for (int i = 0; i <= static_cast<int>(ToastReactions::DontOpen); i++)
+    for (int i = 0; i <= static_cast<int>(ToastReaction::DontOpen); i++)
     {
         toastReactionOptions->insertItem(
-            i, Toasts::findStringFromReaction(static_cast<ToastReactions>(i)));
+            i, Toasts::findStringFromReaction(static_cast<ToastReaction>(i)));
     }
 
     // update when setting changes

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -5,6 +5,7 @@
 #include "controllers/notifications/NotificationModel.hpp"
 #include "singletons/Settings.hpp"
 #include "util/LayoutCreator.hpp"
+#include "widgets/helper/CommonTexts.hpp"
 #include "widgets/helper/EditableModelView.hpp"
 
 #include <QCheckBox>
@@ -16,10 +17,6 @@
 #include <QPushButton>
 #include <QTableView>
 #include <QTimer>
-
-
-#define TOAST_REACTIONS \
-"in browser", "player in browser", "in streamlink", "don't open"
 
 namespace chatterino {
 
@@ -43,17 +40,20 @@ NotificationPage::NotificationPage()
                 settings.append(
                     this->createCheckBox("Enable toasts (Windows 8 or later)",
                                          getSettings()->notificationToast));
-                auto openIn =
-                    settings.emplace<QHBoxLayout>().withoutMargin();
+                auto openIn = settings.emplace<QHBoxLayout>().withoutMargin();
                 {
-                openIn.emplace<QLabel>("Open stream from Toast:  ")->setSizePolicy(
-                                                    QSizePolicy::Maximum, QSizePolicy::Preferred);
-                openIn.append(
-                            this->createComboBox({TOAST_REACTIONS},
-                                                 getSettings()->openFromToast))->setSizePolicy(
-                            QSizePolicy::Maximum, QSizePolicy::Preferred);
+                    openIn.emplace<QLabel>("Open stream from Toast:  ")
+                        ->setSizePolicy(QSizePolicy::Maximum,
+                                        QSizePolicy::Preferred);
+                    openIn
+                        .append(this->createComboBox(
+                            {OPEN_IN_BROWSER, OPEN_PLAYER_IN_BROWSER,
+                             OPEN_IN_STREAMLINK, DONT_OPEN},
+                            getSettings()->openFromToast))
+                        ->setSizePolicy(QSizePolicy::Maximum,
+                                        QSizePolicy::Preferred);
                 }
-                openIn->setContentsMargins(40,0,0,0);
+                openIn->setContentsMargins(40, 0, 0, 0);
                 openIn->setSizeConstraint(QLayout::SetMaximumSize);
 #endif
                 auto customSound =

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -4,8 +4,8 @@
 #include "controllers/notifications/NotificationController.hpp"
 #include "controllers/notifications/NotificationModel.hpp"
 #include "singletons/Settings.hpp"
+#include "singletons/Toasts.hpp"
 #include "util/LayoutCreator.hpp"
-#include "widgets/helper/CommonTexts.hpp"
 #include "widgets/helper/EditableModelView.hpp"
 
 #include <QCheckBox>
@@ -45,10 +45,17 @@ NotificationPage::NotificationPage()
                     openIn.emplace<QLabel>("Open stream from Toast:  ")
                         ->setSizePolicy(QSizePolicy::Maximum,
                                         QSizePolicy::Preferred);
+
                     openIn
                         .append(this->createComboBox(
-                            {OPEN_IN_BROWSER, OPEN_PLAYER_IN_BROWSER,
-                             OPEN_IN_STREAMLINK, DONT_OPEN},
+                            {Toasts::findStringFromReaction(
+                                 ToastReactions::openInBrowser),
+                             Toasts::findStringFromReaction(
+                                 ToastReactions::openInPlayer),
+                             Toasts::findStringFromReaction(
+                                 ToastReactions::openInStreamlink),
+                             Toasts::findStringFromReaction(
+                                 ToastReactions::dontOpen)},
                             getSettings()->openFromToast))
                         ->setSizePolicy(QSizePolicy::Maximum,
                                         QSizePolicy::Preferred);

--- a/src/widgets/settingspages/NotificationPage.cpp
+++ b/src/widgets/settingspages/NotificationPage.cpp
@@ -153,10 +153,10 @@ QComboBox *NotificationPage::createToastReactionComboBox(
         },
         managedConnections);
 
-    QObject::connect(toastReactionOptions, &QComboBox::currentTextChanged,
-                     [setting](const QString &newValue) {
-                         getSettings()->openFromToast.setValue(static_cast<int>(
-                             Toasts::findReactionFromString(newValue)));
+    QObject::connect(toastReactionOptions,
+                     QOverload<int>::of(&QComboBox::currentIndexChanged),
+                     [](const int &newValue) {
+                         getSettings()->openFromToast.setValue(newValue);
                      });
 
     return toastReactionOptions;

--- a/src/widgets/settingspages/NotificationPage.hpp
+++ b/src/widgets/settingspages/NotificationPage.hpp
@@ -15,6 +15,8 @@ public:
     NotificationPage();
 
 private:
+    QComboBox *createToastReactionComboBox(
+        std::vector<pajlada::Signals::ScopedConnection> managedConnections);
 };
 
 }  // namespace chatterino

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -15,6 +15,7 @@
 #include "widgets/Label.hpp"
 #include "widgets/TooltipWidget.hpp"
 #include "widgets/dialogs/SettingsDialog.hpp"
+#include "widgets/helper/CommonTexts.hpp"
 #include "widgets/helper/EffectLabel.hpp"
 #include "widgets/splits/Split.hpp"
 #include "widgets/splits/SplitContainer.hpp"
@@ -268,13 +269,12 @@ std::unique_ptr<QMenu> SplitHeader::createMainMenu()
     });
 #endif
 
-    menu->addAction("Open in browser", this->split_, &Split::openInBrowser);
+    menu->addAction(OPEN_IN_BROWSER, this->split_, &Split::openInBrowser);
 #ifndef USEWEBENGINE
-    menu->addAction("Open player in browser", this->split_,
+    menu->addAction(OPEN_PLAYER_IN_BROWSER, this->split_,
                     &Split::openBrowserPlayer);
 #endif
-    menu->addAction("Open in streamlink", this->split_,
-                    &Split::openInStreamlink);
+    menu->addAction(OPEN_IN_STREAMLINK, this->split_, &Split::openInStreamlink);
     menu->addSeparator();
 
     // sub menu


### PR DESCRIPTION
I think I kinda combined suggestions 2&3 from last merge:

2. Keep two maps (one map<enum class, string>, one map<string, enum class>) in parallel 
3. Make two functions, one for converting an enum class to string with a  simple switch-case, one for converting a string to an enum class with  some if/elseif stuff

Please review and maybe squash commits (?)

![grafik](https://user-images.githubusercontent.com/16636423/56849347-95bc5480-68f3-11e9-8024-ff9b4c983cc0.png)

