### PR TITLE
Fixed display of text in Go to Bottom button for Retina screen.

### DIFF
--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -294,8 +294,12 @@ void ChannelView::scaleChangedEvent(float scale)
 
     if (this->goToBottom_)
     {
+        auto factor = this->qtFontScale();
+#ifdef Q_OS_MACOS
+        factor = scale * 80.f / this->logicalDpiX() * this->devicePixelRatioF();
+#endif
         this->goToBottom_->getLabel().setFont(
-            getFonts()->getFont(FontStyle::UiMedium, this->qtFontScale()));
+            getFonts()->getFont(FontStyle::UiMedium, factor));
     }
 }
 


### PR DESCRIPTION
Unfortunately, "More messages below" button is unreadable.

Before/After.
![image](https://user-images.githubusercontent.com/4051126/56850088-0bc9b700-6906-11e9-82e8-2154d54cd529.png)
