### PR TITLE
implemented fallback logic for corrupted window layout 

### DIFF
--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -474,12 +474,7 @@ void WindowManager::save()
 
     // save file
     QString settingsPath = getPaths()->settingsDirectory + SETTINGS_FILENAME;
-
-    // sometimes chatterino exits/crashes while saving the window layout
-    // this led to corrupted file and users losing their entire layout
-    // QSaveFile used to avoid that
     QSaveFile file(settingsPath);
-
     file.open(QIODevice::WriteOnly | QIODevice::Truncate);
 
     QJsonDocument::JsonFormat format =
@@ -624,7 +619,7 @@ void WindowManager::incGeneration()
     this->generation_++;
 }
 
-QJsonArray WindowManager::buildWindowArray(QString &settingsPath)
+QJsonArray WindowManager::loadWindowArray(const QString &settingsPath)
 {
     QFile file(settingsPath);
     file.open(QIODevice::ReadOnly);

--- a/src/singletons/WindowManager.cpp
+++ b/src/singletons/WindowManager.cpp
@@ -259,7 +259,7 @@ void WindowManager::initialize(Settings &settings, Paths &paths)
 
     // load file
     QString settingsPath = getPaths()->settingsDirectory + SETTINGS_FILENAME;
-    QJsonArray windows_arr = this->buildWindowArray(settingsPath);
+    QJsonArray windows_arr = this->loadWindowArray(settingsPath);
 
     // "deserialize"
     for (QJsonValue window_val : windows_arr)

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -54,6 +54,7 @@ public:
     virtual void initialize(Settings &settings, Paths &paths) override;
     virtual void save() override;
     void closeAll();
+    QJsonArray buildWindowArray(QString &settingsPath);
 
     int getGeneration() const;
     void incGeneration();

--- a/src/singletons/WindowManager.hpp
+++ b/src/singletons/WindowManager.hpp
@@ -54,7 +54,7 @@ public:
     virtual void initialize(Settings &settings, Paths &paths) override;
     virtual void save() override;
     void closeAll();
-    QJsonArray buildWindowArray(QString &settingsPath);
+    QJsonArray loadWindowArray(const QString &settingsPath);
 
     int getGeneration() const;
     void incGeneration();


### PR DESCRIPTION
1. before saving the window-layout a backup will created to avoid corruption due to crashes while saving

2. when starting chatterino and the window-layout file returns an empty window layout (due to corruption) the backup will be read and the layout will be build from this data

(worked with the file I managed to corrupt and a proper backup file, but it's hard to test 100% since the issue is not as easily reproducable. also works with "non-existing" file if backup file exists)