### PR TITLE
Add NixOS Building Instructions

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -18,3 +18,9 @@ install [chatterino2-git](https://aur.archlinux.org/packages/chatterino2-git/) f
 *most likely works the same for other Red Hat-like distros*
 1. `sudo yum install qt-creator qt5-qtmultimedia-devel qt5-qtsvg-devel openssl-devel gstreamer-plugins-ugly gstreamer-plugins-good boost-devel rapidjson-devel`
 1. Open `chatterino.pro` with QT Creator and build
+
+## NixOS 18.09+
+1. enter the development environment with all of the dependencies: `nix-shell -p openssl boost qt5.full`
+1. go into project directory
+1. create build folder `mkdir build && cd build`
+1. `qmake .. && make`


### PR DESCRIPTION
Checked Chatterino2 on [NixOS](https://nixos.org/). Builds and works quite well. Here are instructions just in case.

May I also contribute Chatterino2 to https://github.com/nixos/nixpkgs so it's available to everybody who uses NixOS?