### PR TITLE
 Added {message} parameter for moderation buttons 

### DIFF
--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -48,6 +48,7 @@ struct Message : boost::noncopyable {
     QTime parseTime;
     QString id;
     QString searchText;
+    QString messageText;
     QString loginName;
     QString displayName;
     QString localizedName;

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -97,6 +97,7 @@ MessageBuilder::MessageBuilder(const QString &text)
     this->emplace<TimestampElement>();
     this->emplace<TextElement>(text, MessageElementFlag::Text,
                                MessageColor::System);
+    this->message().messageText = text;
     this->message().searchText = text;
 }
 
@@ -108,6 +109,7 @@ MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text)
                                MessageColor::System);
     this->message().flags.set(MessageFlag::System);
     this->message().flags.set(MessageFlag::DoNotTriggerNotification);
+    this->message().messageText = text;
     this->message().searchText = text;
 }
 
@@ -158,6 +160,7 @@ MessageBuilder::MessageBuilder(TimeoutMessageTag, const QString &username,
     this->emplace<TimestampElement>();
     this->emplace<TextElement>(text, MessageElementFlag::Text,
                                MessageColor::System);
+    this->message().messageText = text;
     this->message().searchText = text;
 }
 
@@ -214,6 +217,7 @@ MessageBuilder::MessageBuilder(const BanAction &action, uint32_t count)
 
     this->emplace<TextElement>(text, MessageElementFlag::Text,
                                MessageColor::System);
+    this->message().messageText = text;
     this->message().searchText = text;
 }
 
@@ -243,6 +247,7 @@ MessageBuilder::MessageBuilder(const UnbanAction &action)
 
     this->emplace<TextElement>(text, MessageElementFlag::Text,
                                MessageColor::System);
+    this->message().messageText = text;
     this->message().searchText = text;
 }
 

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -438,6 +438,7 @@ MessagePtr TwitchMessageBuilder::build()
 
     this->addWords(splits, twitchEmotes);
 
+    this->message().messageText = this->originalMessage_;
     this->message().searchText = this->userName + ": " + this->originalMessage_;
 
     return this->release();

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1670,17 +1670,8 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
 
             value.replace("{user}", layout->getMessage()->loginName)
                 .replace("{channel}", this->channel_->getName())
-                .replace("{msg-id}", layout->getMessage()->id);
-
-            QString messageText;
-            if (value.contains("{message}"))
-            {
-                messageText = layout->getMessage()->searchText;
-                // remove name + : + space to only get the actual message text
-                messageText = messageText.remove(
-                    0, (layout->getMessage()->loginName.length() + 2));
-                value.replace("{message}", messageText);
-            }
+                .replace("{msg-id}", layout->getMessage()->id)
+                .replace("{message}", layout->getMessage()->messageText);
 
             this->channel_->sendMessage(value);
         }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -1667,9 +1667,21 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserAction:
         {
             QString value = link.value;
+
             value.replace("{user}", layout->getMessage()->loginName)
                 .replace("{channel}", this->channel_->getName())
                 .replace("{msg-id}", layout->getMessage()->id);
+
+            QString messageText;
+            if (value.contains("{message}"))
+            {
+                messageText = layout->getMessage()->searchText;
+                // remove name + : + space to only get the actual message text
+                messageText = messageText.remove(
+                    0, (layout->getMessage()->loginName.length() + 2));
+                value.replace("{message}", messageText);
+            }
+
             this->channel_->sendMessage(value);
         }
         break;


### PR DESCRIPTION
Added additional parameter for moderation buttons as requested in #851

Implemented new variable messageText in message-class, since searchText also holds preceding username and colon. (set in src/providers/twitch/TwitchMessageBuilder.cpp )

```c++
this->message().searchText = this->userName + ": " + this->originalMessage_;
```
Also updated src/messages/MessageBuilder.cpp where searchTexts is set, so messageText is not empty.