### PR TITLE
Remove unused messagebuilder constructor

### DIFF
--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -91,16 +91,6 @@ MessageBuilder::MessageBuilder()
 {
 }
 
-MessageBuilder::MessageBuilder(const QString &text)
-    : MessageBuilder()
-{
-    this->emplace<TimestampElement>();
-    this->emplace<TextElement>(text, MessageElementFlag::Text,
-                               MessageColor::System);
-    this->message().messageText = text;
-    this->message().searchText = text;
-}
-
 MessageBuilder::MessageBuilder(SystemMessageTag, const QString &text)
     : MessageBuilder()
 {

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -38,7 +38,6 @@ class MessageBuilder
 {
 public:
     MessageBuilder();
-    MessageBuilder(const QString &text);
     MessageBuilder(SystemMessageTag, const QString &text);
     MessageBuilder(TimeoutMessageTag, const QString &username,
                    const QString &durationInSeconds, const QString &reason,


### PR DESCRIPTION
we now only use the ctor that takes an explicit SystemMessageTag